### PR TITLE
feat: Add fallback address for automatic LAN/VPN switching

### DIFF
--- a/lib/models/router.dart
+++ b/lib/models/router.dart
@@ -5,6 +5,9 @@ class Router {
   final String password;
   final bool useHttps;
   final String? lastKnownHostname;
+  final String? alternateAddress;
+  final bool? alternateUseHttps;
+  final int activeAddressIndex;
 
   Router({
     required this.id,
@@ -13,7 +16,40 @@ class Router {
     required this.password,
     required this.useHttps,
     this.lastKnownHostname,
+    this.alternateAddress,
+    this.alternateUseHttps,
+    this.activeAddressIndex = 0,
   });
+
+  /// The address currently in use (based on last successful connection).
+  String get activeAddress =>
+      activeAddressIndex == 1 && alternateAddress != null
+      ? alternateAddress!
+      : ipAddress;
+
+  /// The protocol for the currently active address.
+  bool get activeUseHttps =>
+      activeAddressIndex == 1 && alternateUseHttps != null
+      ? alternateUseHttps!
+      : useHttps;
+
+  /// The other address (if any).
+  String? get inactiveAddress => alternateAddress == null
+      ? null
+      : activeAddressIndex == 0
+      ? alternateAddress
+      : ipAddress;
+
+  /// The protocol for the inactive address.
+  bool? get inactiveUseHttps => alternateAddress == null
+      ? null
+      : activeAddressIndex == 0
+      ? alternateUseHttps
+      : useHttps;
+
+  /// Whether this router has a fallback address configured.
+  bool get hasFallback =>
+      alternateAddress != null && alternateAddress!.isNotEmpty;
 
   factory Router.fromJson(Map<String, dynamic> json) {
     return Router(
@@ -23,6 +59,12 @@ class Router {
       password: json['password'] as String,
       useHttps: json['useHttps'] == true || json['useHttps'] == 'true',
       lastKnownHostname: json['lastKnownHostname'] as String?,
+      alternateAddress: json['alternateAddress'] as String?,
+      alternateUseHttps: json['alternateUseHttps'] == null
+          ? null
+          : json['alternateUseHttps'] == true ||
+                json['alternateUseHttps'] == 'true',
+      activeAddressIndex: json['activeAddressIndex'] as int? ?? 0,
     );
   }
 
@@ -33,6 +75,9 @@ class Router {
     'password': password,
     'useHttps': useHttps,
     if (lastKnownHostname != null) 'lastKnownHostname': lastKnownHostname,
+    if (alternateAddress != null) 'alternateAddress': alternateAddress,
+    if (alternateUseHttps != null) 'alternateUseHttps': alternateUseHttps,
+    if (activeAddressIndex != 0) 'activeAddressIndex': activeAddressIndex,
   };
 
   Router copyWith({
@@ -42,6 +87,9 @@ class Router {
     String? password,
     bool? useHttps,
     String? lastKnownHostname,
+    String? alternateAddress,
+    bool? alternateUseHttps,
+    int? activeAddressIndex,
   }) {
     return Router(
       id: id ?? this.id,
@@ -50,6 +98,9 @@ class Router {
       password: password ?? this.password,
       useHttps: useHttps ?? this.useHttps,
       lastKnownHostname: lastKnownHostname ?? this.lastKnownHostname,
+      alternateAddress: alternateAddress ?? this.alternateAddress,
+      alternateUseHttps: alternateUseHttps ?? this.alternateUseHttps,
+      activeAddressIndex: activeAddressIndex ?? this.activeAddressIndex,
     );
   }
 }

--- a/lib/models/router.dart
+++ b/lib/models/router.dart
@@ -23,25 +23,21 @@ class Router {
 
   /// The address currently in use (based on last successful connection).
   String get activeAddress =>
-      activeAddressIndex == 1 && alternateAddress != null
-      ? alternateAddress!
-      : ipAddress;
+      activeAddressIndex == 1 && hasFallback ? alternateAddress! : ipAddress;
 
   /// The protocol for the currently active address.
   bool get activeUseHttps =>
-      activeAddressIndex == 1 && alternateUseHttps != null
-      ? alternateUseHttps!
-      : useHttps;
+      activeAddressIndex == 1 && hasFallback ? alternateUseHttps! : useHttps;
 
   /// The other address (if any).
-  String? get inactiveAddress => alternateAddress == null
+  String? get inactiveAddress => !hasFallback
       ? null
       : activeAddressIndex == 0
       ? alternateAddress
       : ipAddress;
 
   /// The protocol for the inactive address.
-  bool? get inactiveUseHttps => alternateAddress == null
+  bool? get inactiveUseHttps => !hasFallback
       ? null
       : activeAddressIndex == 0
       ? alternateUseHttps
@@ -49,7 +45,9 @@ class Router {
 
   /// Whether this router has a fallback address configured.
   bool get hasFallback =>
-      alternateAddress != null && alternateAddress!.isNotEmpty;
+      alternateAddress != null &&
+      alternateAddress!.isNotEmpty &&
+      alternateUseHttps != null;
 
   factory Router.fromJson(Map<String, dynamic> json) {
     return Router(
@@ -90,6 +88,7 @@ class Router {
     String? alternateAddress,
     bool? alternateUseHttps,
     int? activeAddressIndex,
+    bool clearAlternate = false,
   }) {
     return Router(
       id: id ?? this.id,
@@ -98,9 +97,15 @@ class Router {
       password: password ?? this.password,
       useHttps: useHttps ?? this.useHttps,
       lastKnownHostname: lastKnownHostname ?? this.lastKnownHostname,
-      alternateAddress: alternateAddress ?? this.alternateAddress,
-      alternateUseHttps: alternateUseHttps ?? this.alternateUseHttps,
-      activeAddressIndex: activeAddressIndex ?? this.activeAddressIndex,
+      alternateAddress: clearAlternate
+          ? null
+          : alternateAddress ?? this.alternateAddress,
+      alternateUseHttps: clearAlternate
+          ? null
+          : alternateUseHttps ?? this.alternateUseHttps,
+      activeAddressIndex: clearAlternate
+          ? 0
+          : activeAddressIndex ?? this.activeAddressIndex,
     );
   }
 }

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -510,6 +510,28 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
                                               ),
                                               textInputAction:
                                                   TextInputAction.next,
+                                              validator: (value) {
+                                                if (value == null ||
+                                                    value.isEmpty) {
+                                                  return null;
+                                                }
+                                                final parsed = UrlParser.parse(
+                                                  value,
+                                                );
+                                                if (!parsed.isValid) {
+                                                  return parsed.error ??
+                                                      'Invalid address format';
+                                                }
+                                                final primary = UrlParser.parse(
+                                                  _ipController.text,
+                                                );
+                                                if (primary.isValid &&
+                                                    parsed.hostWithPort ==
+                                                        primary.hostWithPort) {
+                                                  return 'Must differ from primary address';
+                                                }
+                                                return null;
+                                              },
                                             ),
                                           ],
                                           const SizedBox(height: 10),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -22,9 +22,11 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
   final _ipController = TextEditingController();
   final _usernameController = TextEditingController(text: 'root');
   final _passwordController = TextEditingController();
+  final _alternateController = TextEditingController();
   final _confirmationController = TextEditingController();
   bool _isCheckingAutoLogin = true;
   bool _passwordVisible = false;
+  bool _showAlternateAddress = false;
   late AnimationController _logoAnimController;
   late AnimationController _progressAnimController;
   bool _isActivatingReviewerMode = false;
@@ -151,6 +153,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
     _ipController.dispose();
     _usernameController.dispose();
     _passwordController.dispose();
+    _alternateController.dispose();
     _confirmationController.dispose();
     _logoAnimController.dispose();
     _progressAnimController.dispose();
@@ -187,13 +190,30 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
         return;
       }
 
-      // Use the parsed values
+      // Parse alternate address if provided
+      String? alternateHost;
+      bool? alternateHttps;
+      final altInput = _alternateController.text.trim();
+      if (altInput.isNotEmpty) {
+        final parsedAlt = UrlParser.parse(altInput);
+        if (parsedAlt.isValid) {
+          if (parsedAlt.hostWithPort == parsedUrl.hostWithPort) {
+            appState.setError('Fallback address must differ from primary');
+            return;
+          }
+          alternateHost = parsedAlt.hostWithPort;
+          alternateHttps = parsedAlt.useHttps;
+        }
+      }
+
       final success = await appState.login(
         parsedUrl.hostWithPort,
         user,
         pass,
         parsedUrl.useHttps,
         fromRouter: false,
+        alternateAddress: alternateHost,
+        alternateUseHttps: alternateHttps,
         context: context,
       );
 
@@ -451,6 +471,47 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
                                               },
                                             ),
                                           ),
+                                          const SizedBox(height: 6),
+                                          if (!_showAlternateAddress)
+                                            Align(
+                                              alignment: Alignment.centerLeft,
+                                              child: TextButton.icon(
+                                                onPressed: () => setState(
+                                                  () => _showAlternateAddress =
+                                                      true,
+                                                ),
+                                                icon: const Icon(
+                                                  Icons.add,
+                                                  size: 18,
+                                                ),
+                                                label: const Text(
+                                                  'Add fallback address',
+                                                ),
+                                                style: TextButton.styleFrom(
+                                                  padding:
+                                                      const EdgeInsets.symmetric(
+                                                        horizontal: 4,
+                                                      ),
+                                                ),
+                                              ),
+                                            )
+                                          else ...[
+                                            TextFormField(
+                                              controller: _alternateController,
+                                              decoration: const InputDecoration(
+                                                labelText: 'Fallback Address',
+                                                border: OutlineInputBorder(),
+                                                prefixIcon: Icon(
+                                                  Icons.swap_horiz,
+                                                ),
+                                                helperText:
+                                                    'Same credentials will be used for both addresses',
+                                                helperMaxLines: 2,
+                                              ),
+                                              textInputAction:
+                                                  TextInputAction.next,
+                                            ),
+                                          ],
                                           const SizedBox(height: 10),
                                           Tooltip(
                                             message:

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -28,16 +28,6 @@ class _MainScreenState extends ConsumerState<MainScreen> {
       _selectedIndex = widget.initialTab!;
     }
     _currentInterfaceToScroll = widget.interfaceToScroll;
-    _checkAuthState();
-  }
-
-  void _checkAuthState() {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      final appState = ref.read(appStateProvider);
-      if (!appState.isAuthenticated) {
-        Navigator.of(context).pushReplacementNamed('/login');
-      }
-    });
   }
 
   @override

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -28,6 +28,16 @@ class _MainScreenState extends ConsumerState<MainScreen> {
       _selectedIndex = widget.initialTab!;
     }
     _currentInterfaceToScroll = widget.interfaceToScroll;
+    _checkAuthState();
+  }
+
+  void _checkAuthState() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final appState = ref.read(appStateProvider);
+      if (!appState.isAuthenticated) {
+        Navigator.of(context).pushReplacementNamed('/login');
+      }
+    });
   }
 
   @override

--- a/lib/screens/manage_routers_screen.dart
+++ b/lib/screens/manage_routers_screen.dart
@@ -183,10 +183,14 @@ class _ManageRoutersScreenState extends ConsumerState<ManageRoutersScreen> {
                                   await appState.removeRouter(router.id);
                                   if (!context.mounted) return;
                                   if (appState.routers.isEmpty) {
-                                    unawaited(Navigator.of(context).pushNamedAndRemoveUntil(
-                                      '/login',
-                                      (route) => false,
-                                    ));
+                                    unawaited(
+                                      Navigator.of(
+                                        context,
+                                      ).pushNamedAndRemoveUntil(
+                                        '/login',
+                                        (route) => false,
+                                      ),
+                                    );
                                   }
                                 }
                               },
@@ -314,43 +318,81 @@ class _ManageRoutersScreenState extends ConsumerState<ManageRoutersScreen> {
                                                                 .username,
                                                           ],
                                                         ),
-                                                        const SizedBox(height: 6),
+                                                        const SizedBox(
+                                                          height: 6,
+                                                        ),
                                                         if (!showAlternate)
                                                           Align(
-                                                            alignment: Alignment.centerLeft,
+                                                            alignment: Alignment
+                                                                .centerLeft,
                                                             child: TextButton.icon(
-                                                              onPressed: () => setState(
-                                                                () => showAlternate = true,
+                                                              onPressed: () =>
+                                                                  setState(
+                                                                    () =>
+                                                                        showAlternate =
+                                                                            true,
+                                                                  ),
+                                                              icon: const Icon(
+                                                                Icons.add,
+                                                                size: 18,
                                                               ),
-                                                              icon: const Icon(Icons.add, size: 18),
-                                                              label: const Text('Add fallback address'),
+                                                              label: const Text(
+                                                                'Add fallback address',
+                                                              ),
                                                             ),
                                                           )
                                                         else
                                                           TextFormField(
-                                                            controller: alternateController,
+                                                            controller:
+                                                                alternateController,
                                                             decoration: const InputDecoration(
-                                                              labelText: 'Fallback Address',
-                                                              border: OutlineInputBorder(),
-                                                              prefixIcon: Icon(Icons.swap_horiz),
-                                                              helperText: 'Same credentials will be used for both addresses',
+                                                              labelText:
+                                                                  'Fallback Address',
+                                                              border:
+                                                                  OutlineInputBorder(),
+                                                              prefixIcon: Icon(
+                                                                Icons
+                                                                    .swap_horiz,
+                                                              ),
+                                                              helperText:
+                                                                  'Same credentials will be used for both addresses',
                                                               helperMaxLines: 2,
                                                             ),
                                                             validator: (value) {
-                                                              if (value == null || value.isEmpty) return null;
-                                                              final parsed = UrlParser.parse(value);
-                                                              if (!parsed.isValid) {
-                                                                return parsed.error ?? 'Invalid address format';
+                                                              if (value ==
+                                                                      null ||
+                                                                  value
+                                                                      .isEmpty) {
+                                                                return null;
                                                               }
-                                                              final primary = UrlParser.parse(ipController.text);
-                                                              if (primary.isValid &&
-                                                                  parsed.hostWithPort == primary.hostWithPort) {
+                                                              final parsed =
+                                                                  UrlParser.parse(
+                                                                    value,
+                                                                  );
+                                                              if (!parsed
+                                                                  .isValid) {
+                                                                return parsed
+                                                                        .error ??
+                                                                    'Invalid address format';
+                                                              }
+                                                              final primary =
+                                                                  UrlParser.parse(
+                                                                    ipController
+                                                                        .text,
+                                                                  );
+                                                              if (primary
+                                                                      .isValid &&
+                                                                  parsed.hostWithPort ==
+                                                                      primary
+                                                                          .hostWithPort) {
                                                                 return 'Must differ from primary address';
                                                               }
                                                               return null;
                                                             },
                                                           ),
-                                                        const SizedBox(height: 10),
+                                                        const SizedBox(
+                                                          height: 10,
+                                                        ),
                                                         TextFormField(
                                                           controller:
                                                               userController,
@@ -519,11 +561,12 @@ class _ManageRoutersScreenState extends ConsumerState<ManageRoutersScreen> {
                                                                       final useHttps =
                                                                           parsedUrl
                                                                               .useHttps;
-                                                                      final altText =
-                                                                          alternateController
-                                                                              .text
-                                                                              .trim();
-                                                                      final parsedAlt = altText.isEmpty
+                                                                      final altText = alternateController
+                                                                          .text
+                                                                          .trim();
+                                                                      final parsedAlt =
+                                                                          altText
+                                                                              .isEmpty
                                                                           ? null
                                                                           : UrlParser.parse(
                                                                               altText,
@@ -562,11 +605,9 @@ class _ManageRoutersScreenState extends ConsumerState<ManageRoutersScreen> {
                                                                           fromRouter:
                                                                               false,
                                                                           alternateAddress:
-                                                                              parsedAlt
-                                                                                  ?.hostWithPort,
+                                                                              parsedAlt?.hostWithPort,
                                                                           alternateUseHttps:
-                                                                              parsedAlt
-                                                                                  ?.useHttps,
+                                                                              parsedAlt?.useHttps,
                                                                           context:
                                                                               context,
                                                                         );

--- a/lib/screens/manage_routers_screen.dart
+++ b/lib/screens/manage_routers_screen.dart
@@ -107,8 +107,6 @@ class _ManageRoutersScreenState extends ConsumerState<ManageRoutersScreen> {
                                       router.id,
                                       context: context,
                                     );
-                                    // Fetch dashboard data before navigating
-                                    await appState.fetchDashboardData();
                                     if (!context.mounted) return;
                                     // Pop all the way back to MainScreen
                                     Navigator.of(
@@ -130,6 +128,19 @@ class _ManageRoutersScreenState extends ConsumerState<ManageRoutersScreen> {
                                   }
                                 }
                               },
+                              onRemoveFallback: router.hasFallback
+                                  ? () async {
+                                      await appState.updateRouter(
+                                        router.copyWith(clearAlternate: true),
+                                      );
+                                      if (isSelected && context.mounted) {
+                                        await appState.selectRouter(
+                                          router.id,
+                                          context: context,
+                                        );
+                                      }
+                                    }
+                                  : null,
                               onDelete: () async {
                                 String routerLabel;
                                 if (isSelected &&
@@ -212,6 +223,8 @@ class _ManageRoutersScreenState extends ConsumerState<ManageRoutersScreen> {
                               ),
                               onPressed: () async {
                                 final ipController = TextEditingController();
+                                final alternateController =
+                                    TextEditingController();
                                 final userController = TextEditingController(
                                   text: 'root',
                                 );
@@ -219,6 +232,7 @@ class _ManageRoutersScreenState extends ConsumerState<ManageRoutersScreen> {
                                 final formKey = GlobalKey<FormState>();
                                 bool obscureText = true;
                                 bool isConnecting = false;
+                                bool showAlternate = false;
                                 String? errorMessage;
                                 try {
                                   await showDialog<void>(
@@ -300,9 +314,43 @@ class _ManageRoutersScreenState extends ConsumerState<ManageRoutersScreen> {
                                                                 .username,
                                                           ],
                                                         ),
-                                                        const SizedBox(
-                                                          height: 20,
-                                                        ),
+                                                        const SizedBox(height: 6),
+                                                        if (!showAlternate)
+                                                          Align(
+                                                            alignment: Alignment.centerLeft,
+                                                            child: TextButton.icon(
+                                                              onPressed: () => setState(
+                                                                () => showAlternate = true,
+                                                              ),
+                                                              icon: const Icon(Icons.add, size: 18),
+                                                              label: const Text('Add fallback address'),
+                                                            ),
+                                                          )
+                                                        else
+                                                          TextFormField(
+                                                            controller: alternateController,
+                                                            decoration: const InputDecoration(
+                                                              labelText: 'Fallback Address',
+                                                              border: OutlineInputBorder(),
+                                                              prefixIcon: Icon(Icons.swap_horiz),
+                                                              helperText: 'Same credentials will be used for both addresses',
+                                                              helperMaxLines: 2,
+                                                            ),
+                                                            validator: (value) {
+                                                              if (value == null || value.isEmpty) return null;
+                                                              final parsed = UrlParser.parse(value);
+                                                              if (!parsed.isValid) {
+                                                                return parsed.error ?? 'Invalid address format';
+                                                              }
+                                                              final primary = UrlParser.parse(ipController.text);
+                                                              if (primary.isValid &&
+                                                                  parsed.hostWithPort == primary.hostWithPort) {
+                                                                return 'Must differ from primary address';
+                                                              }
+                                                              return null;
+                                                            },
+                                                          ),
+                                                        const SizedBox(height: 10),
                                                         TextFormField(
                                                           controller:
                                                               userController,
@@ -471,6 +519,15 @@ class _ManageRoutersScreenState extends ConsumerState<ManageRoutersScreen> {
                                                                       final useHttps =
                                                                           parsedUrl
                                                                               .useHttps;
+                                                                      final altText =
+                                                                          alternateController
+                                                                              .text
+                                                                              .trim();
+                                                                      final parsedAlt = altText.isEmpty
+                                                                          ? null
+                                                                          : UrlParser.parse(
+                                                                              altText,
+                                                                            );
                                                                       final id =
                                                                           '$hostWithPort-$user';
 
@@ -504,6 +561,12 @@ class _ManageRoutersScreenState extends ConsumerState<ManageRoutersScreen> {
                                                                           useHttps,
                                                                           fromRouter:
                                                                               false,
+                                                                          alternateAddress:
+                                                                              parsedAlt
+                                                                                  ?.hostWithPort,
+                                                                          alternateUseHttps:
+                                                                              parsedAlt
+                                                                                  ?.useHttps,
                                                                           context:
                                                                               context,
                                                                         );
@@ -655,6 +718,7 @@ class _ManageRoutersScreenState extends ConsumerState<ManageRoutersScreen> {
                                   // The controllers are only used by the
                                   // dialog above; dispose them once it closes.
                                   ipController.dispose();
+                                  alternateController.dispose();
                                   userController.dispose();
                                   passController.dispose();
                                 }
@@ -679,6 +743,7 @@ class _UnifiedRouterCard extends StatelessWidget {
   final bool isSelected;
   final bool isSwitching;
   final VoidCallback? onTap;
+  final VoidCallback? onRemoveFallback;
   final VoidCallback? onDelete;
 
   const _UnifiedRouterCard({
@@ -687,6 +752,7 @@ class _UnifiedRouterCard extends StatelessWidget {
     required this.isSelected,
     required this.isSwitching,
     this.onTap,
+    this.onRemoveFallback,
     this.onDelete,
   });
 
@@ -782,6 +848,12 @@ class _UnifiedRouterCard extends StatelessWidget {
                       ),
                     ),
                   ),
+                ),
+              if (onRemoveFallback != null)
+                IconButton(
+                  icon: const Icon(Icons.link_off),
+                  tooltip: 'Remove fallback address',
+                  onPressed: onRemoveFallback,
                 ),
               if (onDelete != null)
                 IconButton(

--- a/lib/screens/manage_routers_screen.dart
+++ b/lib/screens/manage_routers_screen.dart
@@ -13,6 +13,13 @@ class ManageRoutersScreen extends ConsumerStatefulWidget {
       _ManageRoutersScreenState();
 }
 
+/// Truncate long addresses (e.g., Tailscale hostnames) to fit in the card.
+/// Keeps the start and the TLD: "gl-be9300-1.tail..."
+String _truncateAddress(String addr, {int maxLen = 24}) {
+  if (addr.length <= maxLen) return addr;
+  return '${addr.substring(0, maxLen - 3)}...';
+}
+
 class _ManageRoutersScreenState extends ConsumerState<ManageRoutersScreen> {
   String? _switchingRouterId;
 
@@ -82,8 +89,9 @@ class _ManageRoutersScreenState extends ConsumerState<ManageRoutersScreen> {
                             ),
                             child: _UnifiedRouterCard(
                               routerTitle: routerTitle,
-                              subtitle:
-                                  '${router.ipAddress} (${router.username})',
+                              subtitle: router.hasFallback
+                                  ? '● ${_truncateAddress(router.activeAddress)}\n○ ${_truncateAddress(router.inactiveAddress!)}'
+                                  : '${router.ipAddress} (${router.username})',
                               isSelected: isSelected,
                               isSwitching: isSwitching,
                               onTap: () async {
@@ -729,11 +737,11 @@ class _UnifiedRouterCard extends StatelessWidget {
                       subtitle,
                       style: theme.textTheme.bodySmall?.copyWith(
                         color: colorScheme.onSurfaceVariant,
-                        fontSize: 12,
+                        fontSize: 11,
                         fontWeight: FontWeight.w400,
                         letterSpacing: 0.1,
                       ),
-                      maxLines: 1,
+                      maxLines: 3,
                       overflow: TextOverflow.ellipsis,
                     ),
                   ],

--- a/lib/screens/manage_routers_screen.dart
+++ b/lib/screens/manage_routers_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:luci_mobile/main.dart';
@@ -168,6 +170,13 @@ class _ManageRoutersScreenState extends ConsumerState<ManageRoutersScreen> {
                                 if (!context.mounted) return;
                                 if (confirm == true) {
                                   await appState.removeRouter(router.id);
+                                  if (!context.mounted) return;
+                                  if (appState.routers.isEmpty) {
+                                    unawaited(Navigator.of(context).pushNamedAndRemoveUntil(
+                                      '/login',
+                                      (route) => false,
+                                    ));
+                                  }
                                 }
                               },
                             ),

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -103,6 +103,50 @@ class RealAuthService implements IAuthService {
   }
 
   @override
+  Future<FallbackLoginResult> loginWithFallback({
+    required String activeAddress,
+    required bool activeHttps,
+    required int activeIndex,
+    String? fallbackAddress,
+    bool? fallbackHttps,
+    required String username,
+    required String password,
+    BuildContext? context,
+  }) async {
+    // Try the active address first
+    final activeOk = await _login(
+      activeAddress,
+      username,
+      password,
+      activeHttps,
+      context: context,
+    );
+    if (activeOk) {
+      return FallbackLoginResult(success: true, usedAddressIndex: activeIndex);
+    }
+
+    // Try the fallback address if available
+    if (fallbackAddress != null && fallbackAddress.isNotEmpty) {
+      final fallbackIndex = activeIndex == 0 ? 1 : 0;
+      final fallbackOk = await _login(
+        fallbackAddress,
+        username,
+        password,
+        fallbackHttps ?? false,
+        context: context,
+      );
+      if (fallbackOk) {
+        return FallbackLoginResult(
+          success: true,
+          usedAddressIndex: fallbackIndex,
+        );
+      }
+    }
+
+    return FallbackLoginResult(success: false, usedAddressIndex: activeIndex);
+  }
+
+  @override
   Future<bool> tryAutoLogin(
     String? ipAddress,
     String? username,

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -126,13 +126,15 @@ class RealAuthService implements IAuthService {
     }
 
     // Try the fallback address if available
-    if (fallbackAddress != null && fallbackAddress.isNotEmpty) {
+    if (fallbackAddress != null &&
+        fallbackAddress.isNotEmpty &&
+        fallbackHttps != null) {
       final fallbackIndex = activeIndex == 0 ? 1 : 0;
       final fallbackOk = await _login(
         fallbackAddress,
         username,
         password,
-        fallbackHttps ?? false,
+        fallbackHttps,
         context: context?.mounted == true ? context : null,
       );
       if (fallbackOk) {

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -133,7 +133,7 @@ class RealAuthService implements IAuthService {
         username,
         password,
         fallbackHttps ?? false,
-        context: context,
+        context: context?.mounted == true ? context : null,
       );
       if (fallbackOk) {
         return FallbackLoginResult(

--- a/lib/services/interfaces/auth_service_interface.dart
+++ b/lib/services/interfaces/auth_service_interface.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/material.dart';
 
+/// Result of a login attempt with fallback.
+class FallbackLoginResult {
+  final bool success;
+  final int usedAddressIndex; // 0 = primary, 1 = alternate
+
+  FallbackLoginResult({required this.success, required this.usedAddressIndex});
+}
+
 abstract class IAuthService {
   Future<void> login(
     String ipAddress,
@@ -8,6 +16,19 @@ abstract class IAuthService {
     bool useHttps, {
     BuildContext? context,
   });
+
+  /// Try active address first, then fallback to the other.
+  Future<FallbackLoginResult> loginWithFallback({
+    required String activeAddress,
+    required bool activeHttps,
+    required int activeIndex,
+    String? fallbackAddress,
+    bool? fallbackHttps,
+    required String username,
+    required String password,
+    BuildContext? context,
+  });
+
   Future<bool> tryAutoLogin(
     String? ipAddress,
     String? username,

--- a/lib/services/mock_auth_service.dart
+++ b/lib/services/mock_auth_service.dart
@@ -57,6 +57,25 @@ class MockAuthService implements IAuthService {
   }
 
   @override
+  Future<FallbackLoginResult> loginWithFallback({
+    required String activeAddress,
+    required bool activeHttps,
+    required int activeIndex,
+    String? fallbackAddress,
+    bool? fallbackHttps,
+    required String username,
+    required String password,
+    BuildContext? context,
+  }) async {
+    await Future.delayed(const Duration(milliseconds: 500));
+    _ipAddress = activeAddress;
+    _useHttps = activeHttps;
+    _isAuthenticated = true;
+    _sysauth = 'mock_sysauth_token_12345';
+    return FallbackLoginResult(success: true, usedAddressIndex: activeIndex);
+  }
+
+  @override
   Future<void> logout() async {
     _sysauth = null;
     _isAuthenticated = false;

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -391,6 +391,11 @@ class AppState extends ChangeNotifier {
 
     // Clear certificates for this specific router
     await _httpClientManager.clearCertificatesForHost(router.ipAddress);
+    if (router.alternateAddress != null) {
+      await _httpClientManager.clearCertificatesForHost(
+        router.alternateAddress!,
+      );
+    }
 
     final needsSwitch = await _routerService!.removeRouter(id);
     if (needsSwitch && _routerService!.routers.isNotEmpty) {
@@ -527,16 +532,21 @@ class AppState extends ChangeNotifier {
 
         if (!fromRouter) {
           if (_routerService != null) {
+            final primaryUseHttps = result.usedAddressIndex == 0
+                ? actualUseHttps
+                : useHttps;
             final router = _routerService!.createRouter(
               ip,
               user,
               pass,
-              actualUseHttps,
+              primaryUseHttps,
             );
             // Preserve alternate address in the new router
             final routerWithAlternate = router.copyWith(
               alternateAddress: alternateAddress,
-              alternateUseHttps: alternateUseHttps,
+              alternateUseHttps: result.usedAddressIndex == 1
+                  ? actualUseHttps
+                  : alternateUseHttps,
               activeAddressIndex: result.usedAddressIndex,
             );
             final idx = _routerService!.routers.indexWhere(
@@ -555,10 +565,15 @@ class AppState extends ChangeNotifier {
                 actualUseHttps != useHttps ||
                 result.usedAddressIndex != router.activeAddressIndex;
             if (needsUpdate) {
-              final updatedRouter = router.copyWith(
-                useHttps: actualUseHttps,
-                activeAddressIndex: result.usedAddressIndex,
-              );
+              final updatedRouter = result.usedAddressIndex == 0
+                  ? router.copyWith(
+                      useHttps: actualUseHttps,
+                      activeAddressIndex: 0,
+                    )
+                  : router.copyWith(
+                      alternateUseHttps: actualUseHttps,
+                      activeAddressIndex: 1,
+                    );
               await updateRouter(updatedRouter);
               if (result.usedAddressIndex != router.activeAddressIndex) {
                 Logger.info(
@@ -1495,8 +1510,10 @@ class AppState extends ChangeNotifier {
             reloginRouter.username,
             reloginRouter.password,
             reloginRouter.activeUseHttps,
+            fromRouter: true,
             alternateAddress: reloginRouter.inactiveAddress,
             alternateUseHttps: reloginRouter.inactiveUseHttps,
+            activeAddressIndex: reloginRouter.activeAddressIndex,
           );
         }
       } else {
@@ -2731,28 +2748,20 @@ class AppState extends ChangeNotifier {
     // If we have a selected router, use loginWithFallback
     final router = _routerService?.selectedRouter;
     if (router != null && _authService != null) {
-      Logger.info(
-        'tryAutoLogin: router=${router.id}, activeIndex=${router.activeAddressIndex}, '
-        'active=${router.activeAddress}, fallback=${router.inactiveAddress}',
-      );
-      final result = await _authService!.loginWithFallback(
-        activeAddress: router.activeAddress,
-        activeHttps: router.activeUseHttps,
-        activeIndex: router.activeAddressIndex,
-        fallbackAddress: router.inactiveAddress,
-        fallbackHttps: router.inactiveUseHttps,
-        username: router.username,
-        password: router.password,
-        context: context?.mounted == true ? context : null,
-      );
-      Logger.info(
-        'tryAutoLogin: result success=${result.success}, usedIndex=${result.usedAddressIndex}',
+      final result = await _serializeAuthOp<FallbackLoginResult>(
+        () => _authService!.loginWithFallback(
+          activeAddress: router.activeAddress,
+          activeHttps: router.activeUseHttps,
+          activeIndex: router.activeAddressIndex,
+          fallbackAddress: router.inactiveAddress,
+          fallbackHttps: router.inactiveUseHttps,
+          username: router.username,
+          password: router.password,
+          context: context?.mounted == true ? context : null,
+        ),
       );
       if (result.success) {
         if (result.usedAddressIndex != router.activeAddressIndex) {
-          Logger.info(
-            'tryAutoLogin: switching activeAddressIndex from ${router.activeAddressIndex} to ${result.usedAddressIndex}',
-          );
           await updateRouter(
             router.copyWith(activeAddressIndex: result.usedAddressIndex),
           );

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -2972,7 +2972,9 @@ class AppState extends ChangeNotifier {
 
       // Use the address that actually succeeded during login (may differ
       // from router.ipAddress after fallback)
-      final activeIp = _authService!.ipAddress!;
+      final activeIp =
+          _authService!.ipAddress ??
+          _routerService!.selectedRouter!.activeAddress;
       final activeHttps = _authService!.useHttps;
 
       final wireless = <String>{};

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -316,6 +316,7 @@ class AppState extends ChangeNotifier {
   }
 
   String? get sysauth => _authService?.sysauth;
+  bool get isAuthenticated => _authService?.isAuthenticated ?? false;
   bool get isLoading => _isLoading;
   String? get errorMessage => _errorMessage;
   bool? get canReboot => _reviewerModeEnabled ? true : _canReboot;
@@ -435,11 +436,14 @@ class AppState extends ChangeNotifier {
     notifyListeners();
     // ignore: use_build_context_synchronously
     final loginSuccess = await login(
-      found.ipAddress,
+      found.activeAddress,
       found.username,
       found.password,
-      found.useHttps,
+      found.activeUseHttps,
       fromRouter: true,
+      alternateAddress: found.inactiveAddress,
+      alternateUseHttps: found.inactiveUseHttps,
+      activeAddressIndex: found.activeAddressIndex,
       context: safeContext, // ignore: use_build_context_synchronously
     );
     // A newer session started while this switch was in flight - it owns the
@@ -466,6 +470,9 @@ class AppState extends ChangeNotifier {
     String pass,
     bool useHttps, {
     bool fromRouter = false,
+    String? alternateAddress,
+    bool? alternateUseHttps,
+    int activeAddressIndex = 0,
     BuildContext? context,
   }) async {
     // A fresh login starts a new session; discard stale results from the
@@ -494,45 +501,66 @@ class AppState extends ChangeNotifier {
     notifyListeners();
 
     try {
-      await _serializeAuthOp<void>(
-        () => _authService!.login(ip, user, pass, useHttps, context: context),
+      final result = await _serializeAuthOp<FallbackLoginResult>(
+        () => _authService!.loginWithFallback(
+          activeAddress: ip,
+          activeHttps: useHttps,
+          activeIndex: activeAddressIndex,
+          fallbackAddress: alternateAddress,
+          fallbackHttps: alternateUseHttps,
+          username: user,
+          password: pass,
+          context: context,
+        ),
       );
       // A newer session (logout / another login) superseded this one while
       // the credential exchange was in flight - do not touch any state.
       if (token != _sessionToken) return false;
 
-      // Check if authentication was successful
-      if (_authService!.isAuthenticated) {
-        // Get the actual protocol used (might be different due to redirect)
+      if (result.success && _authService!.isAuthenticated) {
         final actualUseHttps = _authService!.useHttps;
 
         if (!fromRouter) {
-          // If not from router selection, add or update router with detected protocol
           if (_routerService != null) {
             final router = _routerService!.createRouter(
               ip,
               user,
               pass,
-              actualUseHttps, // Use the detected protocol
+              actualUseHttps,
+            );
+            // Preserve alternate address in the new router
+            final routerWithAlternate = router.copyWith(
+              alternateAddress: alternateAddress,
+              alternateUseHttps: alternateUseHttps,
+              activeAddressIndex: result.usedAddressIndex,
             );
             final idx = _routerService!.routers.indexWhere(
-              (r) => r.id == router.id,
+              (r) => r.id == routerWithAlternate.id,
             );
             if (idx == -1) {
-              await addRouter(router);
+              await addRouter(routerWithAlternate);
             } else {
-              await updateRouter(router);
+              await updateRouter(routerWithAlternate);
             }
           }
-        } else if (actualUseHttps != useHttps && _routerService != null) {
-          // If we're logging in from a saved router and the protocol changed, update it
+        } else if (_routerService != null) {
           final router = _routerService!.selectedRouter;
           if (router != null) {
-            final updatedRouter = router.copyWith(useHttps: actualUseHttps);
-            await updateRouter(updatedRouter);
-            Logger.info(
-              'Updated router protocol from ${useHttps ? "HTTPS" : "HTTP"} to ${actualUseHttps ? "HTTPS" : "HTTP"}',
-            );
+            final needsUpdate =
+                actualUseHttps != useHttps ||
+                result.usedAddressIndex != router.activeAddressIndex;
+            if (needsUpdate) {
+              final updatedRouter = router.copyWith(
+                useHttps: actualUseHttps,
+                activeAddressIndex: result.usedAddressIndex,
+              );
+              await updateRouter(updatedRouter);
+              if (result.usedAddressIndex != router.activeAddressIndex) {
+                Logger.info(
+                  'Switched to ${result.usedAddressIndex == 0 ? "primary" : "alternate"} address',
+                );
+              }
+            }
           }
         }
         await fetchDashboardData();
@@ -681,8 +709,9 @@ class AppState extends ChangeNotifier {
     // If already loading, don't start another request (but this shouldn't prevent pull-to-refresh)
     // We'll let the new request proceed and the loading state will be handled properly
     final selectedRouter = _routerService!.selectedRouter!;
-    final ip = selectedRouter.ipAddress;
-    final useHttps = selectedRouter.useHttps;
+    // Use the address and protocol that actually succeeded during login.
+    final ip = _authService!.ipAddress ?? selectedRouter.activeAddress;
+    final useHttps = _authService!.useHttps;
     final routerPassword = selectedRouter.password;
     // Snapshot the credentials for this exact session: reading the mutable
     // auth service mid-flight could send newer credentials to this router.
@@ -2645,6 +2674,32 @@ class AppState extends ChangeNotifier {
         context: context,
       );
     }
+
+    // If we have a selected router with fallback, use loginWithFallback
+    final router = _routerService?.selectedRouter;
+    if (router != null && _authService != null) {
+      final result = await _authService!.loginWithFallback(
+        activeAddress: router.activeAddress,
+        activeHttps: router.activeUseHttps,
+        activeIndex: router.activeAddressIndex,
+        fallbackAddress: router.inactiveAddress,
+        fallbackHttps: router.inactiveUseHttps,
+        username: router.username,
+        password: router.password,
+        context: context,
+      );
+      if (result.success) {
+        if (result.usedAddressIndex != router.activeAddressIndex) {
+          await updateRouter(
+            router.copyWith(activeAddressIndex: result.usedAddressIndex),
+          );
+        }
+        return true;
+      }
+      return false;
+    }
+
+    // Fallback to legacy auto-login from secure storage
     return await _authService?.tryAutoLogin(
           null,
           null,

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -317,6 +317,8 @@ class AppState extends ChangeNotifier {
 
   String? get sysauth => _authService?.sysauth;
   bool get isAuthenticated => _authService?.isAuthenticated ?? false;
+  bool get hasRouters =>
+      _routerService != null && _routerService!.routers.isNotEmpty;
   bool get isLoading => _isLoading;
   String? get errorMessage => _errorMessage;
   bool? get canReboot => _reviewerModeEnabled ? true : _canReboot;
@@ -393,8 +395,11 @@ class AppState extends ChangeNotifier {
     final needsSwitch = await _routerService!.removeRouter(id);
     if (needsSwitch && _routerService!.routers.isNotEmpty) {
       await selectRouter(_routerService!.routers.first.id);
-    } else if (_routerService!.selectedRouter == null) {
+    } else if (_routerService!.routers.isEmpty) {
+      // All routers deleted — clear auth state so tryAutoLogin won't
+      // succeed with stale credentials and cause a navigation loop
       _dashboardData = null;
+      await _authService?.logout();
       notifyListeners();
     } else {
       notifyListeners();
@@ -614,7 +619,7 @@ class AppState extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> fetchDashboardData() async {
+  Future<void> fetchDashboardData({bool isRetryAfterFallback = false}) async {
     if (_reviewerModeEnabled) {
       // For reviewer mode, return mock data immediately
       _isDashboardLoading = true;
@@ -1013,11 +1018,42 @@ class AppState extends ChangeNotifier {
     } catch (e) {
       // A newer session started; don't surface this fetch's error.
       if (token != _sessionToken) return;
+      final status = e is DioException ? e.response?.statusCode : null;
+      final retryable = e is DioException &&
+          (status == 401 ||
+              status == 403 ||
+              e.type == DioExceptionType.connectionError ||
+              e.type == DioExceptionType.connectionTimeout ||
+              e.type == DioExceptionType.sendTimeout ||
+              e.type == DioExceptionType.receiveTimeout);
+      final router = _routerService?.selectedRouter;
+      if (retryable &&
+          !isRetryAfterFallback &&
+          router != null &&
+          router.hasFallback &&
+          _authService != null) {
+        final result = await _serializeAuthOp<FallbackLoginResult>(
+          () => _authService!.loginWithFallback(
+            activeAddress: router.activeAddress,
+            activeHttps: router.activeUseHttps,
+            activeIndex: router.activeAddressIndex,
+            fallbackAddress: router.inactiveAddress,
+            fallbackHttps: router.inactiveUseHttps,
+            username: router.username,
+            password: router.password,
+          ),
+        );
+        if (token != _sessionToken) return;
+        if (result.success &&
+            result.usedAddressIndex != router.activeAddressIndex) {
+          await updateRouter(
+            router.copyWith(activeAddressIndex: result.usedAddressIndex),
+          );
+          _isDashboardLoading = false;
+          return await fetchDashboardData(isRetryAfterFallback: true);
+        }
+      }
       _dashboardError = userFacingApiError(e);
-      // Log error with stack trace for debugging
-      // print('Dashboard fetch error: $e\n$stack');
-      // Clear dashboard data when there's an error so we don't show stale data
-      _dashboardData = null;
     } finally {
       // A newer session (router switch / re-login / logout) started while this
       // fetch was in flight - drop the stale results instead of clobbering it.
@@ -1217,8 +1253,9 @@ class AppState extends ChangeNotifier {
       return;
     }
 
-    final ip = _routerService!.selectedRouter!.ipAddress;
-    final useHttps = _routerService!.selectedRouter!.useHttps;
+    // Use the address that actually succeeded during login
+    final ip = _authService!.ipAddress ?? _routerService!.selectedRouter!.ipAddress;
+    final useHttps = _authService!.useHttps;
 
     try {
       // Only fetch network devices for throughput calculation
@@ -1450,13 +1487,16 @@ class AppState extends ChangeNotifier {
           onRouterBackOnline!();
         }
 
-        // Force relogin
-        if (_routerService?.selectedRouter != null) {
+        // Force relogin using active address (may have changed via fallback)
+        final reloginRouter = _routerService?.selectedRouter;
+        if (reloginRouter != null) {
           await login(
-            _routerService!.selectedRouter!.ipAddress,
-            _routerService!.selectedRouter!.username,
-            _routerService!.selectedRouter!.password,
-            _routerService!.selectedRouter!.useHttps,
+            reloginRouter.activeAddress,
+            reloginRouter.username,
+            reloginRouter.password,
+            reloginRouter.activeUseHttps,
+            alternateAddress: reloginRouter.inactiveAddress,
+            alternateUseHttps: reloginRouter.inactiveUseHttps,
           );
         }
       } else {
@@ -2675,9 +2715,26 @@ class AppState extends ChangeNotifier {
       );
     }
 
-    // If we have a selected router with fallback, use loginWithFallback
+    // Ensure routers are loaded (constructor fires _initialize async,
+    // so it may not have finished by the time login_screen calls us)
+    if (_routerService != null && _routerService!.routers.isEmpty) {
+      await loadRouters();
+    }
+
+    // No routers saved — nothing to auto-login to.
+    // Also clear any stale credentials from secure storage.
+    if (_routerService == null || _routerService!.routers.isEmpty) {
+      await _authService?.logout();
+      return false;
+    }
+
+    // If we have a selected router, use loginWithFallback
     final router = _routerService?.selectedRouter;
     if (router != null && _authService != null) {
+      Logger.info(
+        'tryAutoLogin: router=${router.id}, activeIndex=${router.activeAddressIndex}, '
+        'active=${router.activeAddress}, fallback=${router.inactiveAddress}',
+      );
       final result = await _authService!.loginWithFallback(
         activeAddress: router.activeAddress,
         activeHttps: router.activeUseHttps,
@@ -2688,8 +2745,14 @@ class AppState extends ChangeNotifier {
         password: router.password,
         context: context,
       );
+      Logger.info(
+        'tryAutoLogin: result success=${result.success}, usedIndex=${result.usedAddressIndex}',
+      );
       if (result.success) {
         if (result.usedAddressIndex != router.activeAddressIndex) {
+          Logger.info(
+            'tryAutoLogin: switching activeAddressIndex from ${router.activeAddressIndex} to ${result.usedAddressIndex}',
+          );
           await updateRouter(
             router.copyWith(activeAddressIndex: result.usedAddressIndex),
           );
@@ -2727,8 +2790,9 @@ class AppState extends ChangeNotifier {
         return {};
       }
 
-      final ip = _routerService!.selectedRouter!.ipAddress;
-      final useHttps = _routerService!.selectedRouter!.useHttps;
+      // Use the address that actually succeeded during login
+      final ip = _authService!.ipAddress ?? _routerService!.selectedRouter!.ipAddress;
+      final useHttps = _authService!.useHttps;
 
       final stationsMap = await _apiService!
           .fetchAllAssociatedWirelessMacsWithContext(
@@ -2892,7 +2956,11 @@ class AppState extends ChangeNotifier {
           _authService?.sysauth == null) {
         return [];
       }
-      final router = _routerService!.selectedRouter!;
+
+      // Use the address that actually succeeded during login (may differ
+      // from router.ipAddress after fallback)
+      final activeIp = _authService!.ipAddress!;
+      final activeHttps = _authService!.useHttps;
 
       final wireless = <String>{};
       Object? wirelessError;
@@ -2900,9 +2968,9 @@ class AppState extends ChangeNotifier {
       try {
         final stationsMap = await _apiService!
             .fetchAllAssociatedWirelessMacsWithContext(
-              ipAddress: router.ipAddress,
+              ipAddress: activeIp,
               sysauth: _authService!.sysauth!,
-              useHttps: router.useHttps,
+              useHttps: activeHttps,
             );
         stationsMap.forEach(
           (_, stations) =>
@@ -2918,9 +2986,9 @@ class AppState extends ChangeNotifier {
       StackTrace? leaseStack;
       try {
         final callRes = await _apiService!.call(
-          router.ipAddress,
+          activeIp,
           _authService!.sysauth!,
-          router.useHttps,
+          activeHttps,
           object: 'luci-rpc',
           method: 'getDHCPLeases',
           params: {},
@@ -3093,17 +3161,17 @@ class AppState extends ChangeNotifier {
           if (_apiService is RealApiService) {
             final real = _apiService as RealApiService;
             final res = await real.loginWithProtocolDetection(
-              r.ipAddress,
+              r.activeAddress,
               r.username,
               r.password,
-              r.useHttps,
+              r.activeUseHttps,
             );
             if (res.token == null) {
               throw Exception('Login failed for ${r.ipAddress}');
             }
             final map = await _apiService!
                 .fetchAllAssociatedWirelessMacsWithContext(
-                  ipAddress: r.ipAddress,
+                  ipAddress: r.activeAddress,
                   sysauth: res.token!,
                   useHttps: res.actualUseHttps,
                 );
@@ -3162,16 +3230,16 @@ class AppState extends ChangeNotifier {
           if (_apiService is RealApiService) {
             final real = _apiService as RealApiService;
             final res = await real.loginWithProtocolDetection(
-              r.ipAddress,
+              r.activeAddress,
               r.username,
               r.password,
-              r.useHttps,
+              r.activeUseHttps,
             );
             if (res.token == null) {
               throw Exception('Login failed for ${r.ipAddress}');
             }
             final callRes = await _apiService!.call(
-              r.ipAddress,
+              r.activeAddress,
               res.token!,
               res.actualUseHttps,
               object: 'luci-rpc',

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -403,9 +403,7 @@ class AppState extends ChangeNotifier {
     } else if (_routerService!.routers.isEmpty) {
       // All routers deleted — clear auth state so tryAutoLogin won't
       // succeed with stale credentials and cause a navigation loop
-      _dashboardData = null;
-      await _authService?.logout();
-      notifyListeners();
+      await logout();
     } else {
       notifyListeners();
     }

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -2743,7 +2743,7 @@ class AppState extends ChangeNotifier {
         fallbackHttps: router.inactiveUseHttps,
         username: router.username,
         password: router.password,
-        context: context,
+        context: context?.mounted == true ? context : null,
       );
       Logger.info(
         'tryAutoLogin: result success=${result.success}, usedIndex=${result.usedAddressIndex}',
@@ -2768,7 +2768,7 @@ class AppState extends ChangeNotifier {
           null,
           null,
           null,
-          context: context,
+          context: context?.mounted == true ? context : null,
         ) ??
         false;
   }

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1034,7 +1034,8 @@ class AppState extends ChangeNotifier {
       // A newer session started; don't surface this fetch's error.
       if (token != _sessionToken) return;
       final status = e is DioException ? e.response?.statusCode : null;
-      final retryable = e is DioException &&
+      final retryable =
+          e is DioException &&
           (status == 401 ||
               status == 403 ||
               e.type == DioExceptionType.connectionError ||
@@ -1059,11 +1060,12 @@ class AppState extends ChangeNotifier {
           ),
         );
         if (token != _sessionToken) return;
-        if (result.success &&
-            result.usedAddressIndex != router.activeAddressIndex) {
-          await updateRouter(
-            router.copyWith(activeAddressIndex: result.usedAddressIndex),
-          );
+        if (result.success) {
+          if (result.usedAddressIndex != router.activeAddressIndex) {
+            await updateRouter(
+              router.copyWith(activeAddressIndex: result.usedAddressIndex),
+            );
+          }
           _isDashboardLoading = false;
           return await fetchDashboardData(isRetryAfterFallback: true);
         }
@@ -1269,7 +1271,8 @@ class AppState extends ChangeNotifier {
     }
 
     // Use the address that actually succeeded during login
-    final ip = _authService!.ipAddress ?? _routerService!.selectedRouter!.ipAddress;
+    final ip =
+        _authService!.ipAddress ?? _routerService!.selectedRouter!.ipAddress;
     final useHttps = _authService!.useHttps;
 
     try {
@@ -2800,7 +2803,8 @@ class AppState extends ChangeNotifier {
       }
 
       // Use the address that actually succeeded during login
-      final ip = _authService!.ipAddress ?? _routerService!.selectedRouter!.ipAddress;
+      final ip =
+          _authService!.ipAddress ?? _routerService!.selectedRouter!.ipAddress;
       final useHttps = _authService!.useHttps;
 
       final stationsMap = await _apiService!

--- a/test/fallback_address_test.dart
+++ b/test/fallback_address_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:luci_mobile/models/router.dart';
+
+void main() {
+  group('Router fallback address', () {
+    test('activeAddress returns primary when index is 0', () {
+      final router = Router(
+        id: 'test-root',
+        ipAddress: '192.168.8.1',
+        username: 'root',
+        password: 'pass',
+        useHttps: false,
+        alternateAddress: 'router.tail.ts.net',
+        alternateUseHttps: true,
+        activeAddressIndex: 0,
+      );
+      expect(router.activeAddress, '192.168.8.1');
+      expect(router.activeUseHttps, false);
+      expect(router.inactiveAddress, 'router.tail.ts.net');
+      expect(router.inactiveUseHttps, true);
+    });
+
+    test('activeAddress returns alternate when index is 1', () {
+      final router = Router(
+        id: 'test-root',
+        ipAddress: '192.168.8.1',
+        username: 'root',
+        password: 'pass',
+        useHttps: false,
+        alternateAddress: 'router.tail.ts.net',
+        alternateUseHttps: true,
+        activeAddressIndex: 1,
+      );
+      expect(router.activeAddress, 'router.tail.ts.net');
+      expect(router.activeUseHttps, true);
+      expect(router.inactiveAddress, '192.168.8.1');
+      expect(router.inactiveUseHttps, false);
+    });
+
+    test('activeAddress falls back to primary when no alternate', () {
+      final router = Router(
+        id: 'test-root',
+        ipAddress: '192.168.8.1',
+        username: 'root',
+        password: 'pass',
+        useHttps: false,
+        activeAddressIndex: 1, // index 1 but no alternate
+      );
+      expect(router.activeAddress, '192.168.8.1');
+      expect(router.inactiveAddress, isNull);
+    });
+
+    test('hasFallback is true only with non-empty alternate', () {
+      expect(
+        Router(
+          id: 'a',
+          ipAddress: 'ip',
+          username: 'u',
+          password: 'p',
+          useHttps: false,
+          alternateAddress: 'alt',
+        ).hasFallback,
+        isTrue,
+      );
+      expect(
+        Router(
+          id: 'a',
+          ipAddress: 'ip',
+          username: 'u',
+          password: 'p',
+          useHttps: false,
+        ).hasFallback,
+        isFalse,
+      );
+      expect(
+        Router(
+          id: 'a',
+          ipAddress: 'ip',
+          username: 'u',
+          password: 'p',
+          useHttps: false,
+          alternateAddress: '',
+        ).hasFallback,
+        isFalse,
+      );
+    });
+
+    test('serialization roundtrip preserves all fields', () {
+      final router = Router(
+        id: 'test-root',
+        ipAddress: '192.168.8.1',
+        username: 'root',
+        password: 'pass',
+        useHttps: false,
+        alternateAddress: 'router.tail.ts.net',
+        alternateUseHttps: true,
+        activeAddressIndex: 1,
+      );
+      final json = router.toJson();
+      final restored = Router.fromJson(json);
+      expect(restored.ipAddress, '192.168.8.1');
+      expect(restored.alternateAddress, 'router.tail.ts.net');
+      expect(restored.alternateUseHttps, true);
+      expect(restored.activeAddressIndex, 1);
+      expect(restored.activeAddress, 'router.tail.ts.net');
+    });
+
+    test('serialization without alternate omits fields', () {
+      final router = Router(
+        id: 'test-root',
+        ipAddress: '192.168.8.1',
+        username: 'root',
+        password: 'pass',
+        useHttps: false,
+      );
+      final json = router.toJson();
+      expect(json.containsKey('alternateAddress'), isFalse);
+      expect(json.containsKey('alternateUseHttps'), isFalse);
+      expect(json.containsKey('activeAddressIndex'), isFalse);
+    });
+
+    test('copyWith updates activeAddressIndex without changing addresses', () {
+      final router = Router(
+        id: 'test-root',
+        ipAddress: '192.168.8.1',
+        username: 'root',
+        password: 'pass',
+        useHttps: false,
+        alternateAddress: 'router.tail.ts.net',
+        alternateUseHttps: true,
+        activeAddressIndex: 0,
+      );
+      final updated = router.copyWith(activeAddressIndex: 1);
+      expect(updated.ipAddress, '192.168.8.1'); // unchanged
+      expect(updated.alternateAddress, 'router.tail.ts.net'); // unchanged
+      expect(updated.id, 'test-root'); // stable ID
+      expect(updated.activeAddressIndex, 1);
+      expect(updated.activeAddress, 'router.tail.ts.net');
+    });
+
+    test('ID stays stable when activeAddressIndex changes', () {
+      final router = Router(
+        id: '192.168.8.1-root',
+        ipAddress: '192.168.8.1',
+        username: 'root',
+        password: 'pass',
+        useHttps: false,
+        alternateAddress: 'tailscale.host',
+      );
+      final switched = router.copyWith(activeAddressIndex: 1);
+      expect(switched.id, router.id);
+    });
+  });
+}

--- a/test/fallback_address_test.dart
+++ b/test/fallback_address_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:luci_mobile/models/router.dart';
+import 'package:luci_mobile/services/api_service.dart';
+import 'package:luci_mobile/services/auth_service.dart';
 
 void main() {
   group('Router fallback address', () {
@@ -59,6 +61,7 @@ void main() {
           password: 'p',
           useHttps: false,
           alternateAddress: 'alt',
+          alternateUseHttps: false,
         ).hasFallback,
         isTrue,
       );
@@ -80,6 +83,18 @@ void main() {
           password: 'p',
           useHttps: false,
           alternateAddress: '',
+          alternateUseHttps: false,
+        ).hasFallback,
+        isFalse,
+      );
+      expect(
+        Router(
+          id: 'a',
+          ipAddress: 'ip',
+          username: 'u',
+          password: 'p',
+          useHttps: false,
+          alternateAddress: 'alt',
         ).hasFallback,
         isFalse,
       );
@@ -150,5 +165,59 @@ void main() {
       final switched = router.copyWith(activeAddressIndex: 1);
       expect(switched.id, router.id);
     });
+
+    test('copyWith can clear the fallback address', () {
+      final router = Router(
+        id: 'test-root',
+        ipAddress: '192.168.8.1',
+        username: 'root',
+        password: 'pass',
+        useHttps: false,
+        alternateAddress: 'router.tail.ts.net',
+        alternateUseHttps: true,
+        activeAddressIndex: 1,
+      );
+
+      final updated = router.copyWith(clearAlternate: true);
+
+      expect(updated.alternateAddress, isNull);
+      expect(updated.alternateUseHttps, isNull);
+      expect(updated.activeAddressIndex, 0);
+      expect(updated.activeAddress, '192.168.8.1');
+    });
+
+    test(
+      'auth does not assume HTTP when fallback protocol is missing',
+      () async {
+        final api = _FailingLoginApi();
+        final result = await RealAuthService(api).loginWithFallback(
+          activeAddress: 'primary',
+          activeHttps: true,
+          activeIndex: 0,
+          fallbackAddress: 'fallback',
+          username: 'root',
+          password: 'pass',
+        );
+
+        expect(result.success, isFalse);
+        expect(api.addresses, ['primary']);
+      },
+    );
   });
+}
+
+class _FailingLoginApi extends RealApiService {
+  final addresses = <String>[];
+
+  @override
+  Future<LoginResult> loginWithProtocolDetection(
+    String ipAddress,
+    String username,
+    String password,
+    bool initialUseHttps, {
+    dynamic context,
+  }) async {
+    addresses.add(ipAddress);
+    return LoginResult(token: null, actualUseHttps: initialUseHttps);
+  }
 }


### PR DESCRIPTION
## Summary

Adds an optional fallback address to the Router model, enabling automatic switching between LAN and remote (VPN/Tailscale/WireGuard) connections without manual intervention.

**All changes are backward-compatible** — routers without a fallback address work exactly as before. The feature is useful for any OpenWrt user with both local and remote access to their router.

> **Note:** This PR builds on top of #56 (GL.iNet router support). The fallback address feature itself is vendor-agnostic, but `app_state.dart` shares code paths with GL.iNet enrichment.

### What's new

**Connection logic:**
- On login failure, the app retries with the fallback address and remembers which one worked
- Dashboard fetch includes automatic fallback retry — if the active address goes down mid-session, the app switches transparently
- All API calls (dashboard, clients, throughput, wireless MACs) use the address that actually succeeded during login
- `activeAddressIndex` tracks which address is current; stored addresses never swap (router ID stays stable)

**Login screen:**
- Collapsible "Add fallback address" field below Router Address
- Same credentials are used for both addresses
- Duplicate address validation

**Manage Routers:**
- Router card shows both addresses with active indicator (● / ○)
- Add Router dialog includes fallback address field
- Deleting all routers properly clears auth state and navigates to login

**Bug fixes:**
- Fixed infinite navigation loop when all routers are deleted
- `tryAutoLogin` returns immediately when no routers exist (no stale credential timeout)

### Screenshots

| Login | Login (expanded) | Manage Routers | Add Router |
|-------|------------------|----------------|------------|
| <img height="500" alt="Login" src="https://github.com/user-attachments/assets/65448698-d5ec-4d7a-959b-79339dbeb909" /> | <img height="500" alt="Login expanded" src="https://github.com/user-attachments/assets/640993d1-d1d7-4572-aeca-6a0bcce31ae4" /> | <img height="500" alt="Manage Routers" src="https://github.com/user-attachments/assets/186c5e58-88ed-479a-a31b-3c07c1f9a250" /> | <img height="500" alt="Add Router" src="https://github.com/user-attachments/assets/bb1c32cc-eb54-469c-980e-ce8975500170" /> |

### Technical details

- `Router` model: `alternateAddress` (String?), `alternateUseHttps` (bool?), `activeAddressIndex` (int, default 0)
- Getters: `activeAddress`, `activeUseHttps`, `inactiveAddress`, `hasFallback` — all derived from index
- `loginWithFallback()` on `IAuthService` — tries active address first, then fallback, returns which succeeded
- `fetchDashboardData` catch block: on failure with fallback router, re-logins with other address and retries once
- Aggregated client/MAC methods use `r.activeAddress` instead of `r.ipAddress`

### Testing

- 8 unit tests for fallback address (Router model serialization, `activeAddress` getter, `copyWith` with index change, `hasFallback`)
- All existing tests continue to pass
- **49 total tests**, 0 analyzer warnings
- Tested on real hardware: GL.iNet GL-BE9300 via LAN and Tailscale, with unreachable primary address triggering fallback

### Checklist

- [x] Code follows Dart style guide (`dart format` applied)
- [x] `flutter analyze` passes (0 errors, 0 warnings)
- [x] `flutter test` passes (49/49)
- [x] Backward compatible — routers without fallback unaffected
- [x] No security vulnerabilities (passwords stored in existing secure storage)
- [x] Screenshots for UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional fallback router addresses with HTTP/HTTPS support.
  * Login now automatically retries using the fallback address when the primary connection fails.
  * Added controls to add, validate, view, switch, and remove fallback addresses.
  * The app remembers the address that successfully connected and uses it for subsequent router operations.
* **Bug Fixes**
  * Improved recovery during dashboard loading, automatic login, and router reboot scenarios.
  * Removing the final saved router now returns to the login screen and clears connection data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->













<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update adds fallback router-address support for authentication and dashboard recovery. The dashboard recovery path was checked for a renewed session on the already-active address and correctly performs the one-time retry.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge based on the validated dashboard recovery behavior.

No blocking failure remains. The previously reported same-address session-renewal failure is fixed: a successful renewal now retries dashboard loading even when the active address does not change.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- - Ran the same-address retry validation script for revision 565e74f^ and HEAD against the same-address session-renewal path.
- - Confirmed the retry\_dashboard\_fetch flag changed from False in the historical setup to True in the current code, indicating that renewing the current address now triggers a dashboard retry.
- - Attempted to run Flutter and Dart native tools and a Flutter test, but the toolchain was unavailable in this environment, so the native test could not be executed.
- - Collected and cataloged artifacts from the run, including the validation script and the dashboard retry logs for before/after fixes and the toolchain unavailability note.

<a href="https://app.greptile.com/trex/runs/20231035/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (7): Last reviewed commit: ["style: apply Dart formatting"](https://github.com/cogwheel0/luci-mobile/commit/7641f7e9510aa810f35b037a71ff2f8ca40b4f9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55905685)</sub>

<!-- /greptile_comment -->