### PR TITLE
feat: WiFi scanner and management

### DIFF
--- a/lib/models/wifi_scan_result.dart
+++ b/lib/models/wifi_scan_result.dart
@@ -48,13 +48,6 @@ class WifiScanResult {
     return defaultValue;
   }
 
-  /// Safely extract a positive integer. Returns null for missing, zero, or
-  /// negative values so callers can fall back to channel-based logic.
-  static int? _safePositiveInt(dynamic value) {
-    final parsed = _safeInt(value, 0);
-    return parsed > 0 ? parsed : null;
-  }
-
   /// Returns a valid Wi-Fi frequency in MHz, or null if the value is missing,
   /// zero, negative, or outside any known Wi-Fi band range.
   /// Valid ranges: 2.4 GHz (2400–2500), 4.9 GHz (4900–5000),
@@ -142,9 +135,10 @@ class WifiEncryption {
       wpaVersion = rawWpa;
     } else if (rawWpa is List && rawWpa.isNotEmpty) {
       // Take the highest WPA version from the array
-      wpaVersion = rawWpa
-          .whereType<int>()
-          .fold(0, (max, v) => v > max ? v : max);
+      wpaVersion = rawWpa.whereType<int>().fold(
+        0,
+        (max, v) => v > max ? v : max,
+      );
       if (wpaVersion == 0) {
         // Try parsing from dynamic types
         for (final v in rawWpa) {
@@ -158,12 +152,13 @@ class WifiEncryption {
     final enabled = json['enabled'] == true || wpaVersion > 0 || wep;
 
     // Auth suites: try multiple key names used by different OpenWrt versions
-    final authSuites = _toStringList(json['auth_suites'])
-        + _toStringList(json['authentication']);
+    final authSuites =
+        _toStringList(json['auth_suites']) +
+        _toStringList(json['authentication']);
 
     // Ciphers: try multiple key names
-    final pairCiphers = _toStringList(json['pair_ciphers'])
-        + _toStringList(json['ciphers']);
+    final pairCiphers =
+        _toStringList(json['pair_ciphers']) + _toStringList(json['ciphers']);
     final groupCiphers = _toStringList(json['group_ciphers']);
 
     // Build description from available data if not provided
@@ -180,10 +175,10 @@ class WifiEncryption {
       final wpaPart = wpaVersion >= 3
           ? 'WPA3'
           : wpaVersion >= 2
-              ? 'WPA2'
-              : wpaVersion >= 1
-                  ? 'WPA'
-                  : 'WPA';
+          ? 'WPA2'
+          : wpaVersion >= 1
+          ? 'WPA'
+          : 'WPA';
       final authPart = authSuites.isNotEmpty
           ? ' ${authSuites.map((s) => s.toUpperCase()).join("/")}'
           : '';

--- a/lib/models/wifi_scan_result.dart
+++ b/lib/models/wifi_scan_result.dart
@@ -28,7 +28,7 @@ class WifiScanResult {
       bssid: _safeString(json['bssid'], ''),
       mode: _safeString(json['mode'], 'Unknown'),
       channel: _safeInt(json['channel'], 0),
-      frequency: _safePositiveInt(json['frequency']),
+      frequency: _safeWifiFrequency(json['frequency']),
       signal: _safeInt(json['signal'], -100),
       quality: _safeInt(json['quality'], 0),
       qualityMax: _safeInt(json['quality_max'], 100),
@@ -53,6 +53,20 @@ class WifiScanResult {
   static int? _safePositiveInt(dynamic value) {
     final parsed = _safeInt(value, 0);
     return parsed > 0 ? parsed : null;
+  }
+
+  /// Returns a valid Wi-Fi frequency in MHz, or null if the value is missing,
+  /// zero, negative, or outside any known Wi-Fi band range.
+  /// Valid ranges: 2.4 GHz (2400–2500), 4.9 GHz (4900–5000),
+  ///               5 GHz (5000–5925), 6 GHz (5925–7125).
+  /// Out-of-range values must fall back to channel-based classification.
+  static int? _safeWifiFrequency(dynamic value) {
+    final parsed = _safeInt(value, 0);
+    if (parsed <= 0) return null;
+    if (parsed >= 2400 && parsed <= 2500) return parsed;
+    if (parsed >= 4900 && parsed <= 5000) return parsed;
+    if (parsed >= 5000 && parsed <= 7125) return parsed;
+    return null; // reject implausible values
   }
 
   /// Safely extract a String from a dynamic value.

--- a/lib/models/wifi_scan_result.dart
+++ b/lib/models/wifi_scan_result.dart
@@ -98,6 +98,7 @@ class WifiScanResult {
     if (frequency != null) {
       if (frequency! >= 5925) return '6 GHz';
       if (frequency! >= 5000) return '5 GHz';
+      if (frequency! >= 4900) return '4.9 GHz';
       return '2.4 GHz';
     }
     // Channel-based fallback cannot distinguish 6 GHz

--- a/lib/models/wifi_scan_result.dart
+++ b/lib/models/wifi_scan_result.dart
@@ -1,0 +1,215 @@
+/// Represents a WiFi network found during a wireless scan.
+class WifiScanResult {
+  final String ssid;
+  final String bssid;
+  final String mode;
+  final int channel;
+  final int signal;
+  final int quality;
+  final int qualityMax;
+  final WifiEncryption encryption;
+
+  WifiScanResult({
+    required this.ssid,
+    required this.bssid,
+    required this.mode,
+    required this.channel,
+    required this.signal,
+    required this.quality,
+    required this.qualityMax,
+    required this.encryption,
+  });
+
+  factory WifiScanResult.fromJson(Map<String, dynamic> json) {
+    return WifiScanResult(
+      ssid: _safeString(json['ssid'], ''),
+      bssid: _safeString(json['bssid'], ''),
+      mode: _safeString(json['mode'], 'Unknown'),
+      channel: _safeInt(json['channel'], 0),
+      signal: _safeInt(json['signal'], -100),
+      quality: _safeInt(json['quality'], 0),
+      qualityMax: _safeInt(json['quality_max'], 100),
+      encryption: WifiEncryption.fromJson(
+        json['encryption'] is Map<String, dynamic>
+            ? json['encryption']
+            : <String, dynamic>{},
+      ),
+    );
+  }
+
+  /// Safely extract an int from a dynamic value (could be int, double, String, List, null).
+  static int _safeInt(dynamic value, int defaultValue) {
+    if (value is int) return value;
+    if (value is double) return value.round();
+    if (value is String) return int.tryParse(value) ?? defaultValue;
+    return defaultValue;
+  }
+
+  /// Safely extract a String from a dynamic value.
+  static String _safeString(dynamic value, String defaultValue) {
+    if (value is String) return value;
+    if (value == null) return defaultValue;
+    return value.toString();
+  }
+
+  /// Signal quality as a percentage (0-100).
+  int get qualityPercent {
+    if (qualityMax <= 0) return 0;
+    return ((quality / qualityMax) * 100).round().clamp(0, 100);
+  }
+
+  /// Human-readable signal strength descriptor.
+  String get signalStrength {
+    if (signal >= -50) return 'Excellent';
+    if (signal >= -60) return 'Good';
+    if (signal >= -70) return 'Fair';
+    if (signal >= -80) return 'Weak';
+    return 'Very Weak';
+  }
+
+  /// Returns the appropriate WiFi signal icon level (0-4 bars).
+  int get signalBars {
+    if (signal >= -50) return 4;
+    if (signal >= -60) return 3;
+    if (signal >= -70) return 2;
+    if (signal >= -80) return 1;
+    return 0;
+  }
+
+  /// Frequency band string based on channel number.
+  String get band {
+    if (channel >= 1 && channel <= 14) return '2.4 GHz';
+    if (channel >= 32 && channel <= 177) return '5 GHz';
+    if (channel >= 1 && channel <= 233) return '6 GHz';
+    return 'Unknown';
+  }
+}
+
+/// Represents WiFi encryption details from a scan result.
+class WifiEncryption {
+  final bool enabled;
+  final String description;
+  final bool wep;
+  final int wpa;
+  final List<String> authSuites;
+  final List<String> pairCiphers;
+  final List<String> groupCiphers;
+
+  WifiEncryption({
+    required this.enabled,
+    required this.description,
+    required this.wep,
+    required this.wpa,
+    required this.authSuites,
+    required this.pairCiphers,
+    required this.groupCiphers,
+  });
+
+  factory WifiEncryption.fromJson(Map<String, dynamic> json) {
+    // 'wpa' can be int (e.g., 2) or List<int> (e.g., [2] or [1,2])
+    int wpaVersion = 0;
+    final rawWpa = json['wpa'];
+    if (rawWpa is int) {
+      wpaVersion = rawWpa;
+    } else if (rawWpa is List && rawWpa.isNotEmpty) {
+      // Take the highest WPA version from the array
+      wpaVersion = rawWpa
+          .whereType<int>()
+          .fold(0, (max, v) => v > max ? v : max);
+      if (wpaVersion == 0) {
+        // Try parsing from dynamic types
+        for (final v in rawWpa) {
+          final parsed = WifiScanResult._safeInt(v, 0);
+          if (parsed > wpaVersion) wpaVersion = parsed;
+        }
+      }
+    }
+
+    final wep = json['wep'] == true;
+    final enabled = json['enabled'] == true || wpaVersion > 0 || wep;
+
+    // Auth suites: try multiple key names used by different OpenWrt versions
+    final authSuites = _toStringList(json['auth_suites'])
+        + _toStringList(json['authentication']);
+
+    // Ciphers: try multiple key names
+    final pairCiphers = _toStringList(json['pair_ciphers'])
+        + _toStringList(json['ciphers']);
+    final groupCiphers = _toStringList(json['group_ciphers']);
+
+    // Build description from available data if not provided
+    String description;
+    final rawDesc = json['description'];
+    if (rawDesc is String && rawDesc.isNotEmpty) {
+      description = rawDesc;
+    } else if (!enabled) {
+      description = 'None';
+    } else if (wep) {
+      description = 'WEP';
+    } else {
+      // Build from wpa version + auth + ciphers
+      final wpaPart = wpaVersion >= 3
+          ? 'WPA3'
+          : wpaVersion >= 2
+              ? 'WPA2'
+              : wpaVersion >= 1
+                  ? 'WPA'
+                  : 'WPA';
+      final authPart = authSuites.isNotEmpty
+          ? ' ${authSuites.map((s) => s.toUpperCase()).join("/")}'
+          : '';
+      final cipherPart = pairCiphers.isNotEmpty
+          ? ' (${pairCiphers.map((s) => s.toUpperCase()).join(", ")})'
+          : '';
+      description = '$wpaPart$authPart$cipherPart';
+    }
+
+    return WifiEncryption(
+      enabled: enabled,
+      description: description,
+      wep: wep,
+      wpa: wpaVersion,
+      authSuites: authSuites,
+      pairCiphers: pairCiphers,
+      groupCiphers: groupCiphers,
+    );
+  }
+
+  static List<String> _toStringList(dynamic value) {
+    if (value is List) {
+      return value.map((e) => e.toString()).toList();
+    }
+    return [];
+  }
+
+  /// Whether this network is open (no encryption).
+  bool get isOpen => !enabled;
+
+  /// Short encryption label for display.
+  String get shortLabel {
+    if (!enabled) return 'Open';
+    if (wep) return 'WEP';
+    if (description.contains('WPA3')) return 'WPA3';
+    if (description.contains('WPA2')) return 'WPA2';
+    if (description.contains('WPA')) return 'WPA';
+    return description;
+  }
+
+  /// Returns the OpenWrt encryption config string for connecting.
+  String get openwrtEncryption {
+    if (!enabled) return 'none';
+    if (wep) return 'wep-open';
+    final hasSAE = authSuites.contains('SAE');
+    final hasPSK = authSuites.contains('PSK');
+    if (hasSAE && hasPSK) {
+      return wpa >= 2 ? 'sae-mixed' : 'sae';
+    }
+    if (hasSAE) return 'sae';
+    if (wpa >= 2) return 'psk2';
+    if (wpa >= 1) return 'psk';
+    return 'psk2'; // Default fallback
+  }
+
+  /// Whether this encryption type requires a password.
+  bool get requiresPassword => enabled;
+}

--- a/lib/models/wifi_scan_result.dart
+++ b/lib/models/wifi_scan_result.dart
@@ -4,6 +4,7 @@ class WifiScanResult {
   final String bssid;
   final String mode;
   final int channel;
+  final int? frequency; // MHz — null when not provided by the scan response
   final int signal;
   final int quality;
   final int qualityMax;
@@ -14,6 +15,7 @@ class WifiScanResult {
     required this.bssid,
     required this.mode,
     required this.channel,
+    this.frequency,
     required this.signal,
     required this.quality,
     required this.qualityMax,
@@ -26,6 +28,7 @@ class WifiScanResult {
       bssid: _safeString(json['bssid'], ''),
       mode: _safeString(json['mode'], 'Unknown'),
       channel: _safeInt(json['channel'], 0),
+      frequency: json['frequency'] != null ? _safeInt(json['frequency'], 0) : null,
       signal: _safeInt(json['signal'], -100),
       quality: _safeInt(json['quality'], 0),
       qualityMax: _safeInt(json['quality_max'], 100),
@@ -76,11 +79,16 @@ class WifiScanResult {
     return 0;
   }
 
-  /// Frequency band string based on channel number.
+  /// Frequency band derived from the scan frequency (MHz), with channel fallback.
   String get band {
+    if (frequency != null) {
+      if (frequency! >= 5925) return '6 GHz';
+      if (frequency! >= 5000) return '5 GHz';
+      return '2.4 GHz';
+    }
+    // Channel-based fallback cannot distinguish 6 GHz
     if (channel >= 1 && channel <= 14) return '2.4 GHz';
-    if (channel >= 32 && channel <= 177) return '5 GHz';
-    if (channel >= 1 && channel <= 233) return '6 GHz';
+    if (channel >= 32) return '5 GHz';
     return 'Unknown';
   }
 }
@@ -201,6 +209,13 @@ class WifiEncryption {
     if (wep) return 'wep-open';
     final hasSAE = authSuites.contains('SAE');
     final hasPSK = authSuites.contains('PSK');
+    final hasOWE = authSuites.contains('OWE');
+    final hasEAP = authSuites.contains('EAP') || authSuites.contains('802.1X');
+    // OWE: opportunistic wireless encryption
+    if (hasOWE) return 'owe';
+    // Enterprise: we cannot map to a PSK mode — return a sentinel so callers
+    // can block the connection instead of creating a broken config.
+    if (hasEAP && !hasSAE && !hasPSK) return 'wpa-eap';
     if (hasSAE && hasPSK) {
       return wpa >= 2 ? 'sae-mixed' : 'sae';
     }
@@ -211,5 +226,12 @@ class WifiEncryption {
   }
 
   /// Whether this encryption type requires a password.
-  bool get requiresPassword => enabled;
+  bool get requiresPassword => enabled && !authSuites.contains('OWE');
+
+  /// Whether this encryption type requires enterprise (EAP) credentials
+  /// that the app cannot configure.
+  bool get isEnterprise {
+    final hasEAP = authSuites.contains('EAP') || authSuites.contains('802.1X');
+    return hasEAP && !authSuites.contains('SAE') && !authSuites.contains('PSK');
+  }
 }

--- a/lib/models/wifi_scan_result.dart
+++ b/lib/models/wifi_scan_result.dart
@@ -28,7 +28,7 @@ class WifiScanResult {
       bssid: _safeString(json['bssid'], ''),
       mode: _safeString(json['mode'], 'Unknown'),
       channel: _safeInt(json['channel'], 0),
-      frequency: json['frequency'] != null ? _safeInt(json['frequency'], 0) : null,
+      frequency: _safePositiveInt(json['frequency']),
       signal: _safeInt(json['signal'], -100),
       quality: _safeInt(json['quality'], 0),
       qualityMax: _safeInt(json['quality_max'], 100),
@@ -46,6 +46,13 @@ class WifiScanResult {
     if (value is double) return value.round();
     if (value is String) return int.tryParse(value) ?? defaultValue;
     return defaultValue;
+  }
+
+  /// Safely extract a positive integer. Returns null for missing, zero, or
+  /// negative values so callers can fall back to channel-based logic.
+  static int? _safePositiveInt(dynamic value) {
+    final parsed = _safeInt(value, 0);
+    return parsed > 0 ? parsed : null;
   }
 
   /// Safely extract a String from a dynamic value.

--- a/lib/screens/interfaces_screen.dart
+++ b/lib/screens/interfaces_screen.dart
@@ -8,6 +8,7 @@ import 'package:luci_mobile/widgets/luci_app_bar.dart';
 import 'package:luci_mobile/design/luci_design_system.dart';
 import 'package:luci_mobile/widgets/luci_loading_states.dart';
 import 'package:luci_mobile/widgets/luci_refresh_components.dart';
+import 'package:luci_mobile/screens/wifi_scan_screen.dart';
 
 class InterfacesScreen extends ConsumerStatefulWidget {
   final String? scrollToInterface;
@@ -479,7 +480,42 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
                     slivers: [
                       SliverToBoxAdapter(child: LuciSectionHeader('Wired')),
                       _buildWiredInterfacesList(),
-                      SliverToBoxAdapter(child: LuciSectionHeader('Wireless')),
+                      SliverToBoxAdapter(
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16.0,
+                            vertical: 8.0,
+                          ),
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Text(
+                                'Wireless',
+                                style: LuciTextStyles.sectionHeader(context),
+                              ),
+                              TextButton.icon(
+                                onPressed: () {
+                                  Navigator.of(context).push(
+                                    MaterialPageRoute(
+                                      builder: (context) =>
+                                          const WifiScanScreen(),
+                                    ),
+                                  );
+                                },
+                                icon: Icon(Icons.cell_tower, size: 16),
+                                label: Text('Radio'),
+                                style: TextButton.styleFrom(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 12,
+                                    vertical: 4,
+                                  ),
+                                  visualDensity: VisualDensity.compact,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
                       _buildWirelessInterfacesList(),
                       SliverToBoxAdapter(
                         child: Padding(
@@ -569,16 +605,18 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
     final interfacesList = <Map<String, dynamic>>[];
 
     final uciRadios = <String, Map>{};
-    final uciInterfaces = <String, Map>{};
+    final uciInterfaces = <String, Map<String, dynamic>>{};
 
-    final uciValues = uciWirelessConfig?['values'] as Map?;
+    // Try 'values' key (real API) then 'wireless' key (mock data)
+    final uciValues = (uciWirelessConfig?['values'] as Map?) ??
+        (uciWirelessConfig?['wireless'] as Map?);
     if (uciValues != null) {
       uciValues.forEach((key, value) {
         final typedValue = value as Map?;
         if (typedValue?['.type'] == 'wifi-device') {
           uciRadios[key] = typedValue!;
         } else if (typedValue?['.type'] == 'wifi-iface') {
-          uciInterfaces[key] = typedValue!;
+          uciInterfaces[key] = Map<String, dynamic>.from(typedValue!);
         }
       });
     }
@@ -597,7 +635,9 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
             }
 
             final isRadioEnabled = uciRadios[radioName]?['disabled'] != '1';
-            final isIfaceEnabled = config['disabled'] != '1';
+            final isIfaceEnabled = config['disabled'] != '1' &&
+                config['disabled'] != 1 &&
+                config['disabled'] != true;
             final isEnabled = isRadioEnabled && isIfaceEnabled;
 
             final name = iface['name'] ?? '';
@@ -608,6 +648,11 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
             final mode = _uciString(config['mode']).toUpperCase().isNotEmpty
                 ? _uciString(config['mode']).toUpperCase()
                 : (iwinfo['mode']?.toString().toUpperCase() ?? 'N/A');
+
+            // Build encryption description
+            final encIwinfo = iwinfo['encryption'] as Map<String, dynamic>?;
+            final encDescription = encIwinfo?['description'] ?? _uciString(config['encryption'], 'N/A');
+
             interfacesList.add({
               'name': _uciString(config['ssid']).isNotEmpty
                   ? _uciString(config['ssid'])
@@ -646,6 +691,7 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
         final isRadioEnabled = uciRadios[radioName]?['disabled'] != '1';
         final isIfaceEnabled = _uciString(config['disabled']) != '1';
         final isEnabled = isRadioEnabled && isIfaceEnabled;
+        final mode = config['mode'] ?? 'N/A';
 
         final name = _uciString(config['ssid'], 'Unnamed');
         interfacesList.add({
@@ -653,11 +699,22 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
           'subtitle':
               '${_uciString(config['mode'], 'N/A').toUpperCase()} • Disabled',
           'isEnabled': isEnabled,
+          'isIfaceEnabled': isIfaceEnabled,
+          'isRadioEnabled': isRadioEnabled,
           'deviceName': radioName,
           'radioName': radioName,
           'ssid': name,
           'interfaceName': name,
           'section': uciName,
+          'uciSection': uciName,
+          'mode': mode,
+          'encryption': config['encryption'] ?? '',
+          'encryptionDescription': config['encryption'] ?? 'N/A',
+          'network': (config['network'] is List)
+              ? (config['network'] as List).join(', ')
+              : config['network']?.toString() ?? '',
+          'channel': config['channel']?.toString() ?? 'auto',
+          'signal': '--',
           'details': {
             'Device': radioName,
             'Mode': _uciString(config['mode'], 'N/A'),
@@ -751,11 +808,166 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
             subtitle: iface['subtitle'],
             isUp: iface['isEnabled'],
             icon: Icons.wifi,
-            details: _buildGenericDetails(context, iface['details']),
+            details: _buildWirelessDetails(context, iface),
             initiallyExpanded: shouldExpand,
           ),
         );
       }, childCount: interfaces.length),
+    );
+  }
+
+  Widget _buildWirelessDetails(
+    BuildContext context,
+    Map<String, dynamic> iface,
+  ) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final details = iface['details'] as Map<String, dynamic>;
+    final uciSection = iface['uciSection'] as String? ?? '';
+    final isIfaceEnabled = iface['isIfaceEnabled'] as bool? ?? true;
+    final mode = iface['mode']?.toString() ?? '';
+    final encDescription = iface['encryptionDescription']?.toString() ?? '';
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Details rows
+        ...details.entries.map((entry) {
+          return _buildDetailRow(context, entry.key, entry.value.toString());
+        }),
+        // Encryption row
+        if (encDescription.isNotEmpty && encDescription != 'N/A')
+          _buildDetailRow(context, 'Encryption', encDescription),
+
+        const Divider(height: 1, indent: 16, endIndent: 16),
+        const SizedBox(height: 8),
+
+        // Management action buttons
+        if (uciSection.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 4.0),
+            child: Column(
+              children: [
+                // Enable/Disable toggle row
+                _WifiToggleRow(
+                  uciSection: uciSection,
+                  isEnabled: isIfaceEnabled,
+                ),
+
+                const SizedBox(height: 8),
+
+                // Action buttons row
+                Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton.icon(
+                        onPressed: () => _showEditWifiSheet(context, iface),
+                        icon: Icon(Icons.edit_outlined, size: 18),
+                        label: const Text('Edit'),
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: colorScheme.primary,
+                          side: BorderSide(
+                            color: colorScheme.primary.withValues(alpha: 0.5),
+                          ),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          padding: const EdgeInsets.symmetric(vertical: 10),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: OutlinedButton.icon(
+                        onPressed: () =>
+                            _showDeleteWifiDialog(context, iface),
+                        icon: Icon(Icons.delete_outline, size: 18),
+                        label: const Text('Remove'),
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: colorScheme.error,
+                          side: BorderSide(
+                            color: colorScheme.error.withValues(alpha: 0.5),
+                          ),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          padding: const EdgeInsets.symmetric(vertical: 10),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+
+                const SizedBox(height: 4),
+
+                // Mode label
+                if (mode.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Text(
+                      mode.toLowerCase() == 'sta'
+                          ? 'Client (Station) mode'
+                          : mode.toLowerCase() == 'ap'
+                              ? 'Access Point mode'
+                              : '${mode.toUpperCase()} mode',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                        fontStyle: FontStyle.italic,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          )
+        else
+          // No UCI section - just show details
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Text(
+              'UCI section unavailable — limited management',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ),
+
+        const SizedBox(height: 8),
+      ],
+    );
+  }
+
+  void _showEditWifiSheet(
+    BuildContext context,
+    Map<String, dynamic> iface,
+  ) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (ctx) => _WifiEditBottomSheet(iface: iface),
+    );
+  }
+
+  void _showDeleteWifiDialog(
+    BuildContext context,
+    Map<String, dynamic> iface,
+  ) {
+    final ssid = iface['ssid']?.toString() ?? 'this interface';
+    final uciSection = iface['uciSection'] as String? ?? '';
+    final mode = iface['mode']?.toString() ?? 'ap';
+    if (uciSection.isEmpty) return;
+
+    showDialog(
+      context: context,
+      builder: (ctx) => _WifiDeleteDialog(
+        ssid: ssid,
+        uciSection: uciSection,
+        mode: mode,
+      ),
     );
   }
 
@@ -1426,5 +1638,690 @@ class _UnifiedNetworkCardState extends State<_UnifiedNetworkCard>
       );
     }
     return card;
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// WiFi Enable/Disable Toggle Row
+// ──────────────────────────────────────────────────────────────────
+
+class _WifiToggleRow extends ConsumerStatefulWidget {
+  final String uciSection;
+  final bool isEnabled;
+
+  const _WifiToggleRow({
+    required this.uciSection,
+    required this.isEnabled,
+  });
+
+  @override
+  ConsumerState<_WifiToggleRow> createState() => _WifiToggleRowState();
+}
+
+class _WifiToggleRowState extends ConsumerState<_WifiToggleRow> {
+  bool _isToggling = false;
+
+  Future<void> _toggle(bool value) async {
+    if (_isToggling) return;
+    setState(() => _isToggling = true);
+
+    final appState = ref.read(appStateProvider);
+    final success = await appState.setWirelessInterfaceEnabled(
+      widget.uciSection,
+      value,
+      context: context,
+    );
+
+    if (mounted) {
+      setState(() => _isToggling = false);
+      if (!success) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('Failed to toggle interface'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            widget.isEnabled ? Icons.wifi : Icons.wifi_off,
+            size: 20,
+            color: widget.isEnabled
+                ? colorScheme.primary
+                : colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              widget.isEnabled ? 'Interface Enabled' : 'Interface Disabled',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+          if (_isToggling)
+            const SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          else
+            Switch(
+              value: widget.isEnabled,
+              onChanged: _toggle,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// WiFi Edit Bottom Sheet
+// ──────────────────────────────────────────────────────────────────
+
+class _WifiEditBottomSheet extends ConsumerStatefulWidget {
+  final Map<String, dynamic> iface;
+
+  const _WifiEditBottomSheet({required this.iface});
+
+  @override
+  ConsumerState<_WifiEditBottomSheet> createState() =>
+      _WifiEditBottomSheetState();
+}
+
+class _WifiEditBottomSheetState extends ConsumerState<_WifiEditBottomSheet> {
+  late TextEditingController _ssidController;
+  late TextEditingController _passwordController;
+  late TextEditingController _networkController;
+  late String _selectedEncryption;
+  bool _obscurePassword = true;
+  bool _isSaving = false;
+  String? _error;
+
+  static const _encryptionOptions = [
+    {'value': 'none', 'label': 'None (Open)'},
+    {'value': 'psk2', 'label': 'WPA2-PSK'},
+    {'value': 'psk', 'label': 'WPA-PSK'},
+    {'value': 'psk-mixed', 'label': 'WPA/WPA2 Mixed PSK'},
+    {'value': 'sae', 'label': 'WPA3-SAE'},
+    {'value': 'sae-mixed', 'label': 'WPA2/WPA3 Mixed'},
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _ssidController = TextEditingController(
+      text: widget.iface['ssid']?.toString() ?? '',
+    );
+    _passwordController = TextEditingController();
+    _networkController = TextEditingController(
+      text: widget.iface['network']?.toString() ?? 'lan',
+    );
+
+    // Map the current encryption to our dropdown values
+    final currentEnc = widget.iface['encryption']?.toString() ?? 'none';
+    _selectedEncryption = _encryptionOptions.any(
+      (o) => o['value'] == currentEnc,
+    )
+        ? currentEnc
+        : 'psk2';
+  }
+
+  @override
+  void dispose() {
+    _ssidController.dispose();
+    _passwordController.dispose();
+    _networkController.dispose();
+    super.dispose();
+  }
+
+  bool get _requiresPassword => _selectedEncryption != 'none';
+
+  Future<void> _save() async {
+    final ssid = _ssidController.text.trim();
+    if (ssid.isEmpty) {
+      setState(() => _error = 'SSID cannot be empty.');
+      return;
+    }
+
+    if (_requiresPassword &&
+        _passwordController.text.isNotEmpty &&
+        _passwordController.text.length < 8 &&
+        _selectedEncryption != 'none') {
+      setState(
+        () => _error = 'Password must be at least 8 characters.',
+      );
+      return;
+    }
+
+    setState(() {
+      _isSaving = true;
+      _error = null;
+    });
+
+    final uciSection = widget.iface['uciSection'] as String? ?? '';
+    if (uciSection.isEmpty) {
+      setState(() {
+        _isSaving = false;
+        _error = 'Cannot identify UCI section for this interface.';
+      });
+      return;
+    }
+
+    // Build values to update
+    final values = <String, String>{
+      'ssid': ssid,
+      'encryption': _selectedEncryption,
+    };
+
+    // Only update password if user typed one
+    if (_passwordController.text.isNotEmpty) {
+      values['key'] = _passwordController.text;
+    }
+
+    // Update network binding
+    final network = _networkController.text.trim();
+    if (network.isNotEmpty) {
+      values['network'] = network;
+    }
+
+    final appState = ref.read(appStateProvider);
+    final success = await appState.modifyWirelessInterface(
+      uciSection,
+      values,
+      context: context,
+    );
+
+    if (!mounted) return;
+
+    if (success) {
+      Navigator.of(context).pop();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Row(
+            children: [
+              const Icon(Icons.check_circle, color: Colors.white, size: 20),
+              const SizedBox(width: 8),
+              Text('Updated "$ssid" — reloading WiFi...'),
+            ],
+          ),
+          backgroundColor: Colors.green.shade700,
+          behavior: SnackBarBehavior.floating,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10),
+          ),
+          duration: const Duration(seconds: 3),
+        ),
+      );
+    } else {
+      setState(() {
+        _isSaving = false;
+        _error = 'Failed to save changes. Please try again.';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final mode = widget.iface['mode']?.toString() ?? 'ap';
+
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(24, 16, 24, 24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Drag handle
+              Center(
+                child: Container(
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: colorScheme.onSurfaceVariant.withValues(alpha: 0.3),
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 20),
+
+              // Header
+              Row(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(10),
+                    decoration: BoxDecoration(
+                      color: colorScheme.primaryContainer.withValues(alpha: 0.3),
+                      shape: BoxShape.circle,
+                    ),
+                    child: Icon(
+                      Icons.edit,
+                      color: colorScheme.primary,
+                      size: 24,
+                    ),
+                  ),
+                  const SizedBox(width: 14),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Edit Wireless Interface',
+                          style: theme.textTheme.titleLarge?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        Text(
+                          '${widget.iface['radioName']} • ${mode.toUpperCase()} mode',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+
+              const SizedBox(height: 24),
+
+              // SSID field
+              _buildLabel(context, 'SSID (Network Name)'),
+              const SizedBox(height: 6),
+              TextField(
+                controller: _ssidController,
+                enabled: !_isSaving,
+                decoration: _inputDecoration(
+                  context,
+                  hintText: 'Enter SSID',
+                  prefixIcon: Icons.wifi,
+                ),
+              ),
+
+              const SizedBox(height: 16),
+
+              // Encryption selector
+              _buildLabel(context, 'Encryption'),
+              const SizedBox(height: 6),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(
+                    color: colorScheme.outline.withValues(alpha: 0.3),
+                  ),
+                  color: colorScheme.surfaceContainerLow,
+                ),
+                child: DropdownButtonHideUnderline(
+                  child: DropdownButton<String>(
+                    value: _selectedEncryption,
+                    isExpanded: true,
+                    icon: Icon(
+                      Icons.arrow_drop_down,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                    items: _encryptionOptions.map((opt) {
+                      return DropdownMenuItem<String>(
+                        value: opt['value'],
+                        child: Text(
+                          opt['label']!,
+                          style: theme.textTheme.bodyMedium,
+                        ),
+                      );
+                    }).toList(),
+                    onChanged: _isSaving
+                        ? null
+                        : (value) {
+                            if (value != null) {
+                              setState(() => _selectedEncryption = value);
+                            }
+                          },
+                  ),
+                ),
+              ),
+
+              // Password field (only for encrypted networks)
+              if (_requiresPassword) ...[
+                const SizedBox(height: 16),
+                _buildLabel(context, 'Password (leave empty to keep current)'),
+                const SizedBox(height: 6),
+                TextField(
+                  controller: _passwordController,
+                  obscureText: _obscurePassword,
+                  enabled: !_isSaving,
+                  decoration: _inputDecoration(
+                    context,
+                    hintText: 'Enter new password',
+                    prefixIcon: Icons.key,
+                    suffixIcon: IconButton(
+                      icon: Icon(
+                        _obscurePassword
+                            ? Icons.visibility_off
+                            : Icons.visibility,
+                      ),
+                      onPressed: () {
+                        setState(() => _obscurePassword = !_obscurePassword);
+                      },
+                    ),
+                  ),
+                ),
+              ],
+
+              const SizedBox(height: 16),
+
+              // Network binding
+              _buildLabel(context, 'Network'),
+              const SizedBox(height: 6),
+              TextField(
+                controller: _networkController,
+                enabled: !_isSaving,
+                decoration: _inputDecoration(
+                  context,
+                  hintText: 'e.g., lan, wwan',
+                  prefixIcon: Icons.lan_outlined,
+                ),
+              ),
+
+              // Error
+              if (_error != null) ...[
+                const SizedBox(height: 12),
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: colorScheme.errorContainer.withValues(alpha: 0.3),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Row(
+                    children: [
+                      Icon(Icons.error_outline, color: colorScheme.error,
+                          size: 18),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          _error!,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: colorScheme.error,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+
+              const SizedBox(height: 20),
+
+              // Warning
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: colorScheme.tertiaryContainer.withValues(alpha: 0.2),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Icon(Icons.info_outline, color: colorScheme.tertiary,
+                        size: 18),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        'Changes will be applied immediately. WiFi will briefly restart.',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: colorScheme.onSurface.withValues(alpha: 0.7),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              const SizedBox(height: 20),
+
+              // Save button
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: _isSaving ? null : _save,
+                  icon: _isSaving
+                      ? SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: colorScheme.onPrimary,
+                          ),
+                        )
+                      : const Icon(Icons.save),
+                  label: Text(
+                    _isSaving ? 'Applying...' : 'Save Changes',
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  style: FilledButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(14),
+                    ),
+                  ),
+                ),
+              ),
+
+              const SizedBox(height: 8),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLabel(BuildContext context, String text) {
+    return Text(
+      text,
+      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+        fontWeight: FontWeight.w600,
+      ),
+    );
+  }
+
+  InputDecoration _inputDecoration(
+    BuildContext context, {
+    required String hintText,
+    required IconData prefixIcon,
+    Widget? suffixIcon,
+  }) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return InputDecoration(
+      hintText: hintText,
+      prefixIcon: Icon(prefixIcon),
+      suffixIcon: suffixIcon,
+      border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide(
+          color: colorScheme.outline.withValues(alpha: 0.3),
+        ),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide(color: colorScheme.primary, width: 2),
+      ),
+      filled: true,
+      fillColor: colorScheme.surfaceContainerLow,
+    );
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// WiFi Delete Confirmation Dialog
+// ──────────────────────────────────────────────────────────────────
+
+class _WifiDeleteDialog extends ConsumerStatefulWidget {
+  final String ssid;
+  final String uciSection;
+  final String mode;
+
+  const _WifiDeleteDialog({
+    required this.ssid,
+    required this.uciSection,
+    required this.mode,
+  });
+
+  @override
+  ConsumerState<_WifiDeleteDialog> createState() => _WifiDeleteDialogState();
+}
+
+class _WifiDeleteDialogState extends ConsumerState<_WifiDeleteDialog> {
+  bool _isDeleting = false;
+
+  Future<void> _delete() async {
+    setState(() => _isDeleting = true);
+
+    final appState = ref.read(appStateProvider);
+    final success = await appState.deleteWirelessInterface(
+      widget.uciSection,
+      mode: widget.mode,
+      context: context,
+    );
+
+    if (!mounted) return;
+
+    Navigator.of(context).pop();
+
+    if (success) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Row(
+            children: [
+              const Icon(Icons.check_circle, color: Colors.white, size: 20),
+              const SizedBox(width: 8),
+              Text('"${widget.ssid}" removed'),
+            ],
+          ),
+          backgroundColor: Colors.green.shade700,
+          behavior: SnackBarBehavior.floating,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10),
+          ),
+          duration: const Duration(seconds: 3),
+        ),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: const Text('Failed to remove interface'),
+          backgroundColor: Theme.of(context).colorScheme.error,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final displayName = widget.ssid.isNotEmpty ? widget.ssid : widget.uciSection;
+    final modeLower = widget.mode.toLowerCase();
+    final isStaMode = modeLower.contains('sta') || 
+                      modeLower.contains('client') || 
+                      modeLower == 'station' ||
+                      modeLower == 'n/a' ||
+                      widget.mode.isEmpty;
+    final warningMessage = isStaMode
+        ? 'This will remove the STA connection from this radio.'
+        : 'WiFi will restart. Clients on this network will be disconnected.';
+
+    return AlertDialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      icon: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: colorScheme.errorContainer.withValues(alpha: 0.3),
+          shape: BoxShape.circle,
+        ),
+        child: Icon(Icons.delete_forever, color: colorScheme.error, size: 32),
+      ),
+      title: const Text('Remove Wireless Interface?'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            'This will permanently remove "$displayName" from your wireless configuration.',
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 12),
+          Container(
+            padding: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              color: colorScheme.errorContainer.withValues(alpha: 0.2),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Row(
+              children: [
+                Icon(Icons.warning_amber, color: colorScheme.error, size: 18),
+                const SizedBox(width: 8),
+                Expanded(
+                child: Text(
+                  warningMessage,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                      color: colorScheme.error,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: _isDeleting ? null : () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _isDeleting ? null : _delete,
+          style: FilledButton.styleFrom(
+            backgroundColor: colorScheme.error,
+            foregroundColor: colorScheme.onError,
+          ),
+          child: _isDeleting
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: Colors.white,
+                  ),
+                )
+              : const Text('Remove'),
+        ),
+      ],
+    );
   }
 }

--- a/lib/screens/interfaces_screen.dart
+++ b/lib/screens/interfaces_screen.dart
@@ -608,7 +608,8 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
     final uciInterfaces = <String, Map<String, dynamic>>{};
 
     // Try 'values' key (real API) then 'wireless' key (mock data)
-    final uciValues = (uciWirelessConfig?['values'] as Map?) ??
+    final uciValues =
+        (uciWirelessConfig?['values'] as Map?) ??
         (uciWirelessConfig?['wireless'] as Map?);
     if (uciValues != null) {
       uciValues.forEach((key, value) {
@@ -635,7 +636,8 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
             }
 
             final isRadioEnabled = uciRadios[radioName]?['disabled'] != '1';
-            final isIfaceEnabled = config['disabled'] != '1' &&
+            final isIfaceEnabled =
+                config['disabled'] != '1' &&
                 config['disabled'] != 1 &&
                 config['disabled'] != true;
             final isEnabled = isRadioEnabled && isIfaceEnabled;
@@ -651,7 +653,9 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
 
             // Build encryption description
             final encIwinfo = iwinfo['encryption'] as Map<String, dynamic>?;
-            final encDescription = encIwinfo?['description'] ?? _uciString(config['encryption'], 'N/A');
+            final encDescription =
+                encIwinfo?['description'] ??
+                _uciString(config['encryption'], 'N/A');
 
             interfacesList.add({
               'name': _uciString(config['ssid']).isNotEmpty
@@ -660,12 +664,23 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
               'subtitle':
                   '$mode • Ch. ${iwinfo['channel']?.toString() ?? _uciString(config['channel'], 'N/A')}',
               'isEnabled': isEnabled,
+              'isIfaceEnabled': isIfaceEnabled,
+              'isRadioEnabled': isRadioEnabled,
               'deviceName': deviceName,
               'radioName': radioName,
               'ssid': ssid,
               'interfaceName': name,
               'section': uciName,
+              'uciSection': uciName,
               'ifname': iface['ifname'] as String?,
+              'mode': mode,
+              'encryption': config['encryption'] ?? '',
+              'encryptionDescription': encDescription,
+              'network': (config['network'] is List)
+                  ? (config['network'] as List).join(', ')
+                  : config['network']?.toString() ?? '',
+              'channel': iwinfo['channel']?.toString() ?? 'auto',
+              'signal': iwinfo['signal']?.toString() ?? '--',
               'details': {
                 'Device': _uciString(config['device'], radioName),
                 'Mode': _uciString(config['mode']).isNotEmpty
@@ -845,7 +860,10 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
         // Management action buttons
         if (uciSection.isNotEmpty)
           Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 4.0),
+            padding: const EdgeInsets.symmetric(
+              horizontal: 12.0,
+              vertical: 4.0,
+            ),
             child: Column(
               children: [
                 // Enable/Disable toggle row
@@ -879,8 +897,7 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
                     const SizedBox(width: 10),
                     Expanded(
                       child: OutlinedButton.icon(
-                        onPressed: () =>
-                            _showDeleteWifiDialog(context, iface),
+                        onPressed: () => _showDeleteWifiDialog(context, iface),
                         icon: Icon(Icons.delete_outline, size: 18),
                         label: const Text('Remove'),
                         style: OutlinedButton.styleFrom(
@@ -908,8 +925,8 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
                       mode.toLowerCase() == 'sta'
                           ? 'Client (Station) mode'
                           : mode.toLowerCase() == 'ap'
-                              ? 'Access Point mode'
-                              : '${mode.toUpperCase()} mode',
+                          ? 'Access Point mode'
+                          : '${mode.toUpperCase()} mode',
                       style: theme.textTheme.bodySmall?.copyWith(
                         color: colorScheme.onSurfaceVariant,
                         fontStyle: FontStyle.italic,
@@ -937,10 +954,7 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
     );
   }
 
-  void _showEditWifiSheet(
-    BuildContext context,
-    Map<String, dynamic> iface,
-  ) {
+  void _showEditWifiSheet(BuildContext context, Map<String, dynamic> iface) {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
@@ -952,10 +966,7 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
     );
   }
 
-  void _showDeleteWifiDialog(
-    BuildContext context,
-    Map<String, dynamic> iface,
-  ) {
+  void _showDeleteWifiDialog(BuildContext context, Map<String, dynamic> iface) {
     final ssid = iface['ssid']?.toString() ?? 'this interface';
     final uciSection = iface['uciSection'] as String? ?? '';
     final mode = iface['mode']?.toString() ?? 'ap';
@@ -963,11 +974,8 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
 
     showDialog(
       context: context,
-      builder: (ctx) => _WifiDeleteDialog(
-        ssid: ssid,
-        uciSection: uciSection,
-        mode: mode,
-      ),
+      builder: (ctx) =>
+          _WifiDeleteDialog(ssid: ssid, uciSection: uciSection, mode: mode),
     );
   }
 
@@ -1202,17 +1210,6 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
           ),
         ],
       ),
-    );
-  }
-
-  Widget _buildGenericDetails(
-    BuildContext context,
-    Map<String, dynamic> details,
-  ) {
-    return Column(
-      children: details.entries.map((entry) {
-        return _buildDetailRow(context, entry.key, entry.value.toString());
-      }).toList(),
     );
   }
 
@@ -1649,10 +1646,7 @@ class _WifiToggleRow extends ConsumerStatefulWidget {
   final String uciSection;
   final bool isEnabled;
 
-  const _WifiToggleRow({
-    required this.uciSection,
-    required this.isEnabled,
-  });
+  const _WifiToggleRow({required this.uciSection, required this.isEnabled});
 
   @override
   ConsumerState<_WifiToggleRow> createState() => _WifiToggleRowState();
@@ -1722,10 +1716,7 @@ class _WifiToggleRowState extends ConsumerState<_WifiToggleRow> {
               child: CircularProgressIndicator(strokeWidth: 2),
             )
           else
-            Switch(
-              value: widget.isEnabled,
-              onChanged: _toggle,
-            ),
+            Switch(value: widget.isEnabled, onChanged: _toggle),
         ],
       ),
     );
@@ -1781,11 +1772,7 @@ class _WifiEditBottomSheetState extends ConsumerState<_WifiEditBottomSheet> {
     // prevent saving until the user makes a valid selection.
     final currentEnc = widget.iface['encryption']?.toString() ?? 'none';
     _originalEncryption = currentEnc;
-    _selectedEncryption = _encryptionOptions.any(
-      (o) => o['value'] == currentEnc,
-    )
-        ? currentEnc
-        : currentEnc; // preserve the raw value; save is blocked for unknown modes
+    _selectedEncryption = currentEnc;
   }
 
   @override
@@ -1816,24 +1803,26 @@ class _WifiEditBottomSheetState extends ConsumerState<_WifiEditBottomSheet> {
 
     // Block unsupported encryption modes (e.g. enterprise WPA-EAP)
     if (!_isEncryptionSupported) {
-      setState(() => _error =
-          'Encryption mode "$_selectedEncryption" cannot be edited here. '
-          'Please select a supported mode.');
+      setState(
+        () => _error =
+            'Encryption mode "$_selectedEncryption" cannot be edited here. '
+            'Please select a supported mode.',
+      );
       return;
     }
 
     // Require a password when changing an open interface to an encrypted one
     if (_changingToEncrypted && _passwordController.text.isEmpty) {
-      setState(() => _error = 'A password is required when enabling encryption.');
+      setState(
+        () => _error = 'A password is required when enabling encryption.',
+      );
       return;
     }
 
     if (_requiresPassword &&
         _passwordController.text.isNotEmpty &&
         _passwordController.text.length < 8) {
-      setState(
-        () => _error = 'Password must be at least 8 characters.',
-      );
+      setState(() => _error = 'Password must be at least 8 characters.');
       return;
     }
 
@@ -1940,7 +1929,9 @@ class _WifiEditBottomSheetState extends ConsumerState<_WifiEditBottomSheet> {
                   Container(
                     padding: const EdgeInsets.all(10),
                     decoration: BoxDecoration(
-                      color: colorScheme.primaryContainer.withValues(alpha: 0.3),
+                      color: colorScheme.primaryContainer.withValues(
+                        alpha: 0.3,
+                      ),
                       shape: BoxShape.circle,
                     ),
                     child: Icon(
@@ -2082,8 +2073,11 @@ class _WifiEditBottomSheetState extends ConsumerState<_WifiEditBottomSheet> {
                   ),
                   child: Row(
                     children: [
-                      Icon(Icons.error_outline, color: colorScheme.error,
-                          size: 18),
+                      Icon(
+                        Icons.error_outline,
+                        color: colorScheme.error,
+                        size: 18,
+                      ),
                       const SizedBox(width: 8),
                       Expanded(
                         child: Text(
@@ -2110,8 +2104,11 @@ class _WifiEditBottomSheetState extends ConsumerState<_WifiEditBottomSheet> {
                 child: Row(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Icon(Icons.info_outline, color: colorScheme.tertiary,
-                        size: 18),
+                    Icon(
+                      Icons.info_outline,
+                      color: colorScheme.tertiary,
+                      size: 18,
+                    ),
                     const SizedBox(width: 8),
                     Expanded(
                       child: Text(
@@ -2169,9 +2166,9 @@ class _WifiEditBottomSheetState extends ConsumerState<_WifiEditBottomSheet> {
   Widget _buildLabel(BuildContext context, String text) {
     return Text(
       text,
-      style: Theme.of(context).textTheme.titleSmall?.copyWith(
-        fontWeight: FontWeight.w600,
-      ),
+      style: Theme.of(
+        context,
+      ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
     );
   }
 
@@ -2272,13 +2269,16 @@ class _WifiDeleteDialogState extends ConsumerState<_WifiDeleteDialog> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final displayName = widget.ssid.isNotEmpty ? widget.ssid : widget.uciSection;
+    final displayName = widget.ssid.isNotEmpty
+        ? widget.ssid
+        : widget.uciSection;
     final modeLower = widget.mode.toLowerCase();
-    final isStaMode = modeLower.contains('sta') || 
-                      modeLower.contains('client') || 
-                      modeLower == 'station' ||
-                      modeLower == 'n/a' ||
-                      widget.mode.isEmpty;
+    final isStaMode =
+        modeLower.contains('sta') ||
+        modeLower.contains('client') ||
+        modeLower == 'station' ||
+        modeLower == 'n/a' ||
+        widget.mode.isEmpty;
     final warningMessage = isStaMode
         ? 'This will remove the STA connection from this radio.'
         : 'WiFi will restart. Clients on this network will be disconnected.';
@@ -2313,9 +2313,9 @@ class _WifiDeleteDialogState extends ConsumerState<_WifiDeleteDialog> {
                 Icon(Icons.warning_amber, color: colorScheme.error, size: 18),
                 const SizedBox(width: 8),
                 Expanded(
-                child: Text(
-                  warningMessage,
-                  style: theme.textTheme.bodySmall?.copyWith(
+                  child: Text(
+                    warningMessage,
+                    style: theme.textTheme.bodySmall?.copyWith(
                       color: colorScheme.error,
                     ),
                   ),

--- a/lib/screens/interfaces_screen.dart
+++ b/lib/screens/interfaces_screen.dart
@@ -613,11 +613,11 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
         (uciWirelessConfig?['wireless'] as Map?);
     if (uciValues != null) {
       uciValues.forEach((key, value) {
-        final typedValue = value as Map?;
-        if (typedValue?['.type'] == 'wifi-device') {
-          uciRadios[key] = typedValue!;
-        } else if (typedValue?['.type'] == 'wifi-iface') {
-          uciInterfaces[key] = Map<String, dynamic>.from(typedValue!);
+        if (value is! Map) return;
+        if (value['.type'] == 'wifi-device') {
+          uciRadios[key.toString()] = value;
+        } else if (value['.type'] == 'wifi-iface') {
+          uciInterfaces[key.toString()] = Map<String, dynamic>.from(value);
         }
       });
     }
@@ -1851,8 +1851,9 @@ class _WifiEditBottomSheetState extends ConsumerState<_WifiEditBottomSheet> {
       'encryption': _selectedEncryption!,
     };
 
-    // Only update password if user typed one
-    if (_passwordController.text.isNotEmpty) {
+    if (!_requiresPassword) {
+      values['key'] = '';
+    } else if (_passwordController.text.isNotEmpty) {
       values['key'] = _passwordController.text;
     }
 

--- a/lib/screens/interfaces_screen.dart
+++ b/lib/screens/interfaces_screen.dart
@@ -1751,6 +1751,7 @@ class _WifiEditBottomSheetState extends ConsumerState<_WifiEditBottomSheet> {
   late TextEditingController _passwordController;
   late TextEditingController _networkController;
   late String _selectedEncryption;
+  late String _originalEncryption; // tracks what was set before editing
   bool _obscurePassword = true;
   bool _isSaving = false;
   String? _error;
@@ -1775,13 +1776,16 @@ class _WifiEditBottomSheetState extends ConsumerState<_WifiEditBottomSheet> {
       text: widget.iface['network']?.toString() ?? 'lan',
     );
 
-    // Map the current encryption to our dropdown values
+    // Map the current encryption to our dropdown values, preserving it if
+    // supported. For unknown/enterprise values, keep them for display but
+    // prevent saving until the user makes a valid selection.
     final currentEnc = widget.iface['encryption']?.toString() ?? 'none';
+    _originalEncryption = currentEnc;
     _selectedEncryption = _encryptionOptions.any(
       (o) => o['value'] == currentEnc,
     )
         ? currentEnc
-        : 'psk2';
+        : currentEnc; // preserve the raw value; save is blocked for unknown modes
   }
 
   @override
@@ -1792,7 +1796,16 @@ class _WifiEditBottomSheetState extends ConsumerState<_WifiEditBottomSheet> {
     super.dispose();
   }
 
-  bool get _requiresPassword => _selectedEncryption != 'none';
+  bool get _requiresPassword =>
+      _selectedEncryption != 'none' && _selectedEncryption != 'owe';
+
+  bool get _isEncryptionSupported =>
+      _encryptionOptions.any((o) => o['value'] == _selectedEncryption);
+
+  /// True when switching from an open interface to a password-protected one.
+  bool get _changingToEncrypted =>
+      (_originalEncryption == 'none' || _originalEncryption == 'owe') &&
+      _requiresPassword;
 
   Future<void> _save() async {
     final ssid = _ssidController.text.trim();
@@ -1801,10 +1814,23 @@ class _WifiEditBottomSheetState extends ConsumerState<_WifiEditBottomSheet> {
       return;
     }
 
+    // Block unsupported encryption modes (e.g. enterprise WPA-EAP)
+    if (!_isEncryptionSupported) {
+      setState(() => _error =
+          'Encryption mode "$_selectedEncryption" cannot be edited here. '
+          'Please select a supported mode.');
+      return;
+    }
+
+    // Require a password when changing an open interface to an encrypted one
+    if (_changingToEncrypted && _passwordController.text.isEmpty) {
+      setState(() => _error = 'A password is required when enabling encryption.');
+      return;
+    }
+
     if (_requiresPassword &&
         _passwordController.text.isNotEmpty &&
-        _passwordController.text.length < 8 &&
-        _selectedEncryption != 'none') {
+        _passwordController.text.length < 8) {
       setState(
         () => _error = 'Password must be at least 8 characters.',
       );

--- a/lib/screens/interfaces_screen.dart
+++ b/lib/screens/interfaces_screen.dart
@@ -652,7 +652,8 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
                 : (iwinfo['mode']?.toString().toUpperCase() ?? 'N/A');
 
             // Build encryption description
-            final encIwinfo = iwinfo['encryption'] as Map<String, dynamic>?;
+            final rawEncIwinfo = iwinfo['encryption'];
+            final encIwinfo = rawEncIwinfo is Map ? rawEncIwinfo : null;
             final encDescription =
                 encIwinfo?['description'] ??
                 _uciString(config['encryption'], 'N/A');
@@ -674,7 +675,7 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
               'uciSection': uciName,
               'ifname': iface['ifname'] as String?,
               'mode': mode,
-              'encryption': config['encryption'] ?? '',
+              'encryption': _uciString(config['encryption']),
               'encryptionDescription': encDescription,
               'network': (config['network'] is List)
                   ? (config['network'] as List).join(', ')
@@ -723,8 +724,8 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
           'section': uciName,
           'uciSection': uciName,
           'mode': mode,
-          'encryption': config['encryption'] ?? '',
-          'encryptionDescription': config['encryption'] ?? 'N/A',
+          'encryption': _uciString(config['encryption']),
+          'encryptionDescription': _uciString(config['encryption'], 'N/A'),
           'network': (config['network'] is List)
               ? (config['network'] as List).join(', ')
               : config['network']?.toString() ?? '',
@@ -1741,7 +1742,7 @@ class _WifiEditBottomSheetState extends ConsumerState<_WifiEditBottomSheet> {
   late TextEditingController _ssidController;
   late TextEditingController _passwordController;
   late TextEditingController _networkController;
-  late String _selectedEncryption;
+  String? _selectedEncryption;
   late String _originalEncryption; // tracks what was set before editing
   bool _obscurePassword = true;
   bool _isSaving = false;
@@ -1767,12 +1768,15 @@ class _WifiEditBottomSheetState extends ConsumerState<_WifiEditBottomSheet> {
       text: widget.iface['network']?.toString() ?? 'lan',
     );
 
-    // Map the current encryption to our dropdown values, preserving it if
-    // supported. For unknown/enterprise values, keep them for display but
-    // prevent saving until the user makes a valid selection.
-    final currentEnc = widget.iface['encryption']?.toString() ?? 'none';
+    final rawEncryption = widget.iface['encryption']?.toString().trim() ?? '';
+    final currentEnc = (rawEncryption.isEmpty ? 'none' : rawEncryption)
+        .split('+')
+        .first;
     _originalEncryption = currentEnc;
-    _selectedEncryption = currentEnc;
+    _selectedEncryption =
+        _encryptionOptions.any((option) => option['value'] == currentEnc)
+        ? currentEnc
+        : null;
   }
 
   @override
@@ -1784,9 +1788,12 @@ class _WifiEditBottomSheetState extends ConsumerState<_WifiEditBottomSheet> {
   }
 
   bool get _requiresPassword =>
-      _selectedEncryption != 'none' && _selectedEncryption != 'owe';
+      _selectedEncryption != null &&
+      _selectedEncryption != 'none' &&
+      _selectedEncryption != 'owe';
 
   bool get _isEncryptionSupported =>
+      _selectedEncryption != null &&
       _encryptionOptions.any((o) => o['value'] == _selectedEncryption);
 
   /// True when switching from an open interface to a password-protected one.
@@ -1804,9 +1811,7 @@ class _WifiEditBottomSheetState extends ConsumerState<_WifiEditBottomSheet> {
     // Block unsupported encryption modes (e.g. enterprise WPA-EAP)
     if (!_isEncryptionSupported) {
       setState(
-        () => _error =
-            'Encryption mode "$_selectedEncryption" cannot be edited here. '
-            'Please select a supported mode.',
+        () => _error = 'Select a supported encryption mode before saving.',
       );
       return;
     }
@@ -1843,7 +1848,7 @@ class _WifiEditBottomSheetState extends ConsumerState<_WifiEditBottomSheet> {
     // Build values to update
     final values = <String, String>{
       'ssid': ssid,
-      'encryption': _selectedEncryption,
+      'encryption': _selectedEncryption!,
     };
 
     // Only update password if user typed one
@@ -1867,8 +1872,9 @@ class _WifiEditBottomSheetState extends ConsumerState<_WifiEditBottomSheet> {
     if (!mounted) return;
 
     if (success) {
+      final messenger = ScaffoldMessenger.of(context);
       Navigator.of(context).pop();
-      ScaffoldMessenger.of(context).showSnackBar(
+      messenger.showSnackBar(
         SnackBar(
           content: Row(
             children: [
@@ -2023,7 +2029,12 @@ class _WifiEditBottomSheetState extends ConsumerState<_WifiEditBottomSheet> {
               // Password field (only for encrypted networks)
               if (_requiresPassword) ...[
                 const SizedBox(height: 16),
-                _buildLabel(context, 'Password (leave empty to keep current)'),
+                _buildLabel(
+                  context,
+                  _changingToEncrypted
+                      ? 'Password (required)'
+                      : 'Password (leave empty to keep current)',
+                ),
                 const SizedBox(height: 6),
                 TextField(
                   controller: _passwordController,
@@ -2233,10 +2244,12 @@ class _WifiDeleteDialogState extends ConsumerState<_WifiDeleteDialog> {
 
     if (!mounted) return;
 
+    final messenger = ScaffoldMessenger.of(context);
+    final errorColor = Theme.of(context).colorScheme.error;
     Navigator.of(context).pop();
 
     if (success) {
-      ScaffoldMessenger.of(context).showSnackBar(
+      messenger.showSnackBar(
         SnackBar(
           content: Row(
             children: [
@@ -2254,10 +2267,10 @@ class _WifiDeleteDialogState extends ConsumerState<_WifiDeleteDialog> {
         ),
       );
     } else {
-      ScaffoldMessenger.of(context).showSnackBar(
+      messenger.showSnackBar(
         SnackBar(
           content: const Text('Failed to remove interface'),
-          backgroundColor: Theme.of(context).colorScheme.error,
+          backgroundColor: errorColor,
           behavior: SnackBarBehavior.floating,
         ),
       );
@@ -2275,9 +2288,7 @@ class _WifiDeleteDialogState extends ConsumerState<_WifiDeleteDialog> {
     final isStaMode =
         modeLower.contains('sta') ||
         modeLower.contains('client') ||
-        modeLower == 'station' ||
-        modeLower == 'n/a' ||
-        widget.mode.isEmpty;
+        modeLower == 'station';
     final warningMessage = isStaMode
         ? 'This will remove the STA connection from this radio.'
         : 'WiFi will restart. Clients on this network will be disconnected.';

--- a/lib/screens/interfaces_screen.dart
+++ b/lib/screens/interfaces_screen.dart
@@ -2228,7 +2228,6 @@ class _WifiDeleteDialogState extends ConsumerState<_WifiDeleteDialog> {
     final appState = ref.read(appStateProvider);
     final success = await appState.deleteWirelessInterface(
       widget.uciSection,
-      mode: widget.mode,
       context: context,
     );
 

--- a/lib/screens/more_screen.dart
+++ b/lib/screens/more_screen.dart
@@ -11,6 +11,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 import 'package:luci_mobile/config/app_config.dart';
 import 'package:luci_mobile/screens/manage_routers_screen.dart';
+import 'package:luci_mobile/screens/wifi_scan_screen.dart';
 import 'package:luci_mobile/utils/http_client_manager.dart';
 import 'package:luci_mobile/state/app_state.dart';
 
@@ -316,6 +317,20 @@ class _MoreScreenState extends ConsumerState<MoreScreen> {
                 final rebootEnabled = canReboot == true && !isRebooting;
                 return _MoreScreenSection(
                   tiles: [
+                    _buildMoreTile(
+                      context,
+                      icon: Icons.wifi_find,
+                      iconColor: Theme.of(context).colorScheme.primary,
+                      title: 'WiFi Scanner',
+                      subtitle: 'Scan and connect to wireless networks',
+                      onTap: () {
+                        Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (context) => const WifiScanScreen(),
+                          ),
+                        );
+                      },
+                    ),
                     _buildMoreTile(
                       context,
                       icon: accessError != null

--- a/lib/screens/wifi_scan_screen.dart
+++ b/lib/screens/wifi_scan_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:luci_mobile/main.dart';
 import 'package:luci_mobile/models/wifi_scan_result.dart';
 import 'package:luci_mobile/design/luci_design_system.dart';
+import 'package:luci_mobile/state/app_state.dart';
 
 class WifiScanScreen extends ConsumerStatefulWidget {
   const WifiScanScreen({super.key});
@@ -20,6 +21,7 @@ class _WifiScanScreenState extends ConsumerState<WifiScanScreen>
   String? _selectedRadio; // radioName key (e.g., 'radio0')
   List<Map<String, String>> _radioDevices = [];
   late AnimationController _pulseController;
+  AppState? _appState;
   // Scan generation counter — incremented whenever a scan is cancelled or
   // superseded. Completions from older generations are ignored.
   int _scanGeneration = 0;
@@ -37,11 +39,16 @@ class _WifiScanScreenState extends ConsumerState<WifiScanScreen>
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _appState ??= ref.read(appStateProvider);
+  }
+
+  @override
   void dispose() {
     // Invalidate any in-flight scan so it cannot update state after disposal.
     _scanGeneration++;
-    final appState = ref.read(appStateProvider);
-    appState.cancelWirelessScan();
+    _appState?.cancelWirelessScan();
     _pulseController.dispose();
     super.dispose();
   }

--- a/lib/screens/wifi_scan_screen.dart
+++ b/lib/screens/wifi_scan_screen.dart
@@ -20,6 +20,9 @@ class _WifiScanScreenState extends ConsumerState<WifiScanScreen>
   String? _selectedRadio; // radioName key (e.g., 'radio0')
   List<Map<String, String>> _radioDevices = [];
   late AnimationController _pulseController;
+  // Scan generation counter — incremented whenever a scan is cancelled or
+  // superseded. Completions from older generations are ignored.
+  int _scanGeneration = 0;
 
   @override
   void initState() {
@@ -35,6 +38,10 @@ class _WifiScanScreenState extends ConsumerState<WifiScanScreen>
 
   @override
   void dispose() {
+    // Invalidate any in-flight scan so it cannot update state after disposal.
+    _scanGeneration++;
+    final appState = ref.read(appStateProvider);
+    appState.cancelWirelessScan();
     _pulseController.dispose();
     super.dispose();
   }
@@ -64,6 +71,9 @@ class _WifiScanScreenState extends ConsumerState<WifiScanScreen>
     final ifname = _selectedIfname;
     if (ifname == null) return;
 
+    // Increment generation to invalidate any previous in-flight scan.
+    final generation = ++_scanGeneration;
+
     setState(() {
       _isScanning = true;
       _error = null;
@@ -78,7 +88,8 @@ class _WifiScanScreenState extends ConsumerState<WifiScanScreen>
         context: context,
       );
 
-      if (!mounted) return;
+      // Discard if a newer scan was started or this one was cancelled.
+      if (!mounted || generation != _scanGeneration) return;
       setState(() {
         _scanResults = results;
         _isScanning = false;
@@ -87,19 +98,22 @@ class _WifiScanScreenState extends ConsumerState<WifiScanScreen>
         }
       });
     } catch (e) {
-      if (!mounted) return;
+      if (!mounted || generation != _scanGeneration) return;
       setState(() {
         _isScanning = false;
         _error = 'Scan failed: $e';
       });
     }
-    if (mounted) {
+    if (mounted && generation == _scanGeneration) {
       _pulseController.stop();
       _pulseController.reset();
     }
   }
 
   void _stopScan() {
+    // Invalidate current generation before cancelling so the awaited future
+    // is ignored even if it completes before the cancel takes effect.
+    _scanGeneration++;
     final appState = ref.read(appStateProvider);
     appState.cancelWirelessScan();
     setState(() {
@@ -787,10 +801,13 @@ class _ConnectBottomSheet extends ConsumerStatefulWidget {
 
 class _ConnectBottomSheetState extends ConsumerState<_ConnectBottomSheet> {
   final _passwordController = TextEditingController();
+  final _hiddenSsidController = TextEditingController();
   bool _obscurePassword = true;
   bool _isConnecting = false;
   String? _selectedRadio;
   String? _error;
+
+  bool get _isHidden => widget.network.ssid.isEmpty;
 
   @override
   void initState() {
@@ -807,6 +824,7 @@ class _ConnectBottomSheetState extends ConsumerState<_ConnectBottomSheet> {
   @override
   void dispose() {
     _passwordController.dispose();
+    _hiddenSsidController.dispose();
     super.dispose();
   }
 
@@ -814,6 +832,22 @@ class _ConnectBottomSheetState extends ConsumerState<_ConnectBottomSheet> {
     if (_selectedRadio == null) {
       setState(() {
         _error = 'Please select a radio device.';
+      });
+      return;
+    }
+
+    // For hidden networks, an SSID must be entered by the user.
+    if (_isHidden && _hiddenSsidController.text.trim().isEmpty) {
+      setState(() {
+        _error = 'Please enter the network name (SSID).';
+      });
+      return;
+    }
+
+    // Block unsupported enterprise networks.
+    if (widget.network.encryption.isEnterprise) {
+      setState(() {
+        _error = 'Enterprise (EAP) networks are not supported for connecting here.';
       });
       return;
     }
@@ -841,10 +875,15 @@ class _ConnectBottomSheetState extends ConsumerState<_ConnectBottomSheet> {
       _error = null;
     });
 
+    // Use the entered SSID for hidden networks; otherwise use the scanned SSID.
+    final ssid = _isHidden
+        ? _hiddenSsidController.text.trim()
+        : widget.network.ssid;
+
     final appState = ref.read(appStateProvider);
     final success = await appState.connectToWirelessNetwork(
       radioDevice: _selectedRadio!,
-      ssid: widget.network.ssid,
+      ssid: ssid,
       encryption: widget.network.encryption.openwrtEncryption,
       password: _passwordController.text,
       bssid: widget.network.bssid,
@@ -1037,6 +1076,35 @@ class _ConnectBottomSheetState extends ConsumerState<_ConnectBottomSheet> {
                   ),
                 ),
               ),
+
+              // Hidden network SSID field
+              if (_isHidden) ...[
+                const SizedBox(height: LuciSpacing.md),
+                Text(
+                  'Network Name (SSID):',
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: LuciSpacing.sm),
+                TextField(
+                  controller: _hiddenSsidController,
+                  enabled: !_isConnecting,
+                  decoration: InputDecoration(
+                    hintText: 'Enter hidden network name',
+                    prefixIcon: const Icon(Icons.wifi_find),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide(
+                        color: colorScheme.outline.withValues(alpha: 0.3),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
 
               // Password field (only for encrypted networks)
               if (network.encryption.requiresPassword) ...[

--- a/lib/screens/wifi_scan_screen.dart
+++ b/lib/screens/wifi_scan_screen.dart
@@ -1,0 +1,1226 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:luci_mobile/main.dart';
+import 'package:luci_mobile/models/wifi_scan_result.dart';
+import 'package:luci_mobile/design/luci_design_system.dart';
+
+class WifiScanScreen extends ConsumerStatefulWidget {
+  const WifiScanScreen({super.key});
+
+  @override
+  ConsumerState<WifiScanScreen> createState() => _WifiScanScreenState();
+}
+
+class _WifiScanScreenState extends ConsumerState<WifiScanScreen>
+    with SingleTickerProviderStateMixin {
+  List<WifiScanResult> _scanResults = [];
+  bool _isScanning = false;
+  bool _isRestarting = false;
+  String? _error;
+  String? _selectedRadio; // radioName key (e.g., 'radio0')
+  List<Map<String, String>> _radioDevices = [];
+  late AnimationController _pulseController;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulseController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1200),
+    );
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadRadioDevices();
+    });
+  }
+
+  @override
+  void dispose() {
+    _pulseController.dispose();
+    super.dispose();
+  }
+
+  void _loadRadioDevices() {
+    final appState = ref.read(appStateProvider);
+    final devices = appState.getAvailableRadioDevices();
+    setState(() {
+      _radioDevices = devices;
+      if (devices.isNotEmpty) {
+        _selectedRadio = devices.first['radioName'];
+      }
+    });
+  }
+
+  /// Get the interface name to use for scanning based on selected radio
+  String? get _selectedIfname {
+    if (_selectedRadio == null) return null;
+    final device = _radioDevices.firstWhere(
+      (d) => d['radioName'] == _selectedRadio,
+      orElse: () => {},
+    );
+    return device['ifname'];
+  }
+
+  Future<void> _startScan() async {
+    final ifname = _selectedIfname;
+    if (ifname == null) return;
+
+    setState(() {
+      _isScanning = true;
+      _error = null;
+      _scanResults = [];
+    });
+    _pulseController.repeat();
+
+    try {
+      final appState = ref.read(appStateProvider);
+      final results = await appState.scanWirelessNetworks(
+        device: ifname,
+        context: context,
+      );
+
+      if (!mounted) return;
+      setState(() {
+        _scanResults = results;
+        _isScanning = false;
+        if (results.isEmpty) {
+          _error = 'No networks found. Try scanning again.';
+        }
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isScanning = false;
+        _error = 'Scan failed: $e';
+      });
+    }
+    if (mounted) {
+      _pulseController.stop();
+      _pulseController.reset();
+    }
+  }
+
+  void _stopScan() {
+    final appState = ref.read(appStateProvider);
+    appState.cancelWirelessScan();
+    setState(() {
+      _isScanning = false;
+    });
+    _pulseController.stop();
+    _pulseController.reset();
+  }
+
+  Future<void> _restartRadio() async {
+    if (_selectedRadio == null || _isRestarting) return;
+
+    setState(() {
+      _isRestarting = true;
+      _error = null;
+    });
+
+    try {
+      final appState = ref.read(appStateProvider);
+      final success = await appState.restartWirelessRadio(
+        _selectedRadio!,
+        context: context,
+      );
+
+      if (!mounted) return;
+      setState(() => _isRestarting = false);
+
+      if (success) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Row(
+              children: [
+                const Icon(Icons.check_circle, color: Colors.white, size: 20),
+                const SizedBox(width: 8),
+                Text('$_selectedRadio restarted'),
+              ],
+            ),
+            backgroundColor: Colors.green.shade700,
+            behavior: SnackBarBehavior.floating,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(10),
+            ),
+            duration: const Duration(seconds: 3),
+          ),
+        );
+        _loadRadioDevices();
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('Failed to restart radio'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isRestarting = false;
+        _error = 'Restart failed: $e';
+      });
+    }
+  }
+
+  void _showConnectDialog(WifiScanResult network) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (context) => _ConnectBottomSheet(
+        network: network,
+        radioDevices: _radioDevices,
+        selectedDevice: _selectedRadio,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('WiFi Scanner'),
+        centerTitle: true,
+        elevation: 0,
+      ),
+      body: Column(
+        children: [
+          // Device selector and scan button
+          _buildControlBar(theme, colorScheme),
+
+          // Results area
+          Expanded(
+            child: _isScanning
+                ? _buildScanningIndicator(theme, colorScheme)
+                : _scanResults.isEmpty
+                    ? _buildEmptyState(theme, colorScheme)
+                    : _buildResultsList(theme, colorScheme),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildControlBar(ThemeData theme, ColorScheme colorScheme) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(
+        LuciSpacing.md,
+        LuciSpacing.sm,
+        LuciSpacing.md,
+        LuciSpacing.md,
+      ),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        boxShadow: [
+          BoxShadow(
+            color: colorScheme.shadow.withValues(alpha: 0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Radio device selector (full width)
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: colorScheme.outline.withValues(alpha: 0.3),
+              ),
+              color: colorScheme.surfaceContainerLow,
+            ),
+            child: DropdownButtonHideUnderline(
+              child: DropdownButton<String>(
+                value: _selectedRadio,
+                isExpanded: true,
+                icon: Icon(
+                  Icons.arrow_drop_down,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+                hint: Text(
+                  'Select radio',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                items: _radioDevices.map((device) {
+                  final radioName = device['radioName'] ?? '';
+                  final ssid = device['ssid'] ?? '';
+                  final band = device['band'] ?? '';
+                  final label = band.isNotEmpty
+                      ? '$radioName ($band)'
+                      : radioName;
+                  final subtitle = ssid != radioName && ssid.isNotEmpty
+                      ? ssid
+                      : null;
+                  return DropdownMenuItem<String>(
+                    value: radioName,
+                    child: Row(
+                      children: [
+                        Icon(
+                          Icons.router,
+                          size: 18,
+                          color: colorScheme.primary,
+                        ),
+                        const SizedBox(width: 8),
+                        Flexible(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Text(
+                                label,
+                                overflow: TextOverflow.ellipsis,
+                                style: theme.textTheme.bodyMedium,
+                              ),
+                              if (subtitle != null)
+                                Text(
+                                  subtitle,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: theme.textTheme.bodySmall?.copyWith(
+                                    color: colorScheme.onSurfaceVariant,
+                                  ),
+                                ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                }).toList(),
+                onChanged: (_isScanning || _isRestarting)
+                    ? null
+                    : (value) {
+                        setState(() {
+                          _selectedRadio = value;
+                        });
+                      },
+              ),
+            ),
+          ),
+          const SizedBox(height: 10),
+          // Scan + Restart Radio buttons row
+          Row(
+            children: [
+              // Scan / Stop button
+              Expanded(
+                child: _isScanning
+                    ? OutlinedButton.icon(
+                        onPressed: _stopScan,
+                        icon: const Icon(Icons.stop, size: 20),
+                        label: const Text('Stop Scan'),
+                        style: OutlinedButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(vertical: 12),
+                          foregroundColor: colorScheme.error,
+                          side: BorderSide(
+                            color: colorScheme.error.withValues(alpha: 0.5),
+                          ),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                        ),
+                      )
+                    : FilledButton.icon(
+                        onPressed: _isRestarting || _selectedRadio == null
+                            ? null
+                            : _startScan,
+                        icon: const Icon(Icons.radar, size: 20),
+                        label: const Text('Scan Networks'),
+                        style: FilledButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(vertical: 12),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                        ),
+                      ),
+              ),
+              const SizedBox(width: 10),
+              // Restart Radio button
+              Expanded(
+                child: OutlinedButton.icon(
+                  onPressed: _isScanning || _isRestarting || _selectedRadio == null
+                      ? null
+                      : _restartRadio,
+                  icon: _isRestarting
+                      ? SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: colorScheme.primary,
+                          ),
+                        )
+                      : const Icon(Icons.restart_alt, size: 20),
+                  label: Text(_isRestarting ? 'Restarting...' : 'Restart Radio'),
+                  style: OutlinedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                    side: BorderSide(
+                      color: colorScheme.primary.withValues(alpha: 0.5),
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildScanningIndicator(ThemeData theme, ColorScheme colorScheme) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          AnimatedBuilder(
+            animation: _pulseController,
+            builder: (context, child) {
+              return Stack(
+                alignment: Alignment.center,
+                children: [
+                  // Outer pulse ring
+                  Transform.scale(
+                    scale: 1.0 + (_pulseController.value * 0.6),
+                    child: Container(
+                      width: 100,
+                      height: 100,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        border: Border.all(
+                          color: colorScheme.primary.withValues(
+                            alpha: 0.3 * (1.0 - _pulseController.value),
+                          ),
+                          width: 2,
+                        ),
+                      ),
+                    ),
+                  ),
+                  // Middle pulse ring
+                  Transform.scale(
+                    scale: 1.0 + (_pulseController.value * 0.35),
+                    child: Container(
+                      width: 100,
+                      height: 100,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        border: Border.all(
+                          color: colorScheme.primary.withValues(
+                            alpha: 0.5 * (1.0 - _pulseController.value),
+                          ),
+                          width: 2,
+                        ),
+                      ),
+                    ),
+                  ),
+                  // Center icon
+                  Container(
+                    width: 80,
+                    height: 80,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: colorScheme.primaryContainer.withValues(alpha: 0.3),
+                    ),
+                    child: Icon(
+                      Icons.radar,
+                      size: 40,
+                      color: colorScheme.primary,
+                    ),
+                  ),
+                ],
+              );
+            },
+          ),
+          const SizedBox(height: LuciSpacing.lg),
+          Text(
+            'Scanning for networks...',
+            style: theme.textTheme.titleMedium?.copyWith(
+              color: colorScheme.onSurface,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(height: LuciSpacing.sm),
+          Text(
+            'This may take a few seconds',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(ThemeData theme, ColorScheme colorScheme) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.wifi_find,
+            size: 64,
+            color: colorScheme.onSurfaceVariant.withValues(alpha: 0.4),
+          ),
+          const SizedBox(height: LuciSpacing.md),
+          Text(
+            _error ?? 'Select a radio and tap Scan\nto find nearby WiFi networks',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: _error != null
+                  ? colorScheme.error
+                  : colorScheme.onSurfaceVariant,
+            ),
+          ),
+          if (_radioDevices.isEmpty) ...[
+            const SizedBox(height: LuciSpacing.md),
+            Text(
+              'No wireless radios detected.\nMake sure your router has wireless interfaces.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildResultsList(ThemeData theme, ColorScheme colorScheme) {
+    // Separate networks with SSIDs from hidden ones
+    final visibleNetworks =
+        _scanResults.where((r) => r.ssid.isNotEmpty).toList();
+    final hiddenNetworks =
+        _scanResults.where((r) => r.ssid.isEmpty).toList();
+
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: LuciSpacing.sm),
+      children: [
+        // Header
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: LuciSpacing.md,
+            vertical: LuciSpacing.sm,
+          ),
+          child: Row(
+            children: [
+              Text(
+                'AVAILABLE NETWORKS',
+                style: LuciTextStyles.sectionHeader(context),
+              ),
+              const Spacer(),
+              Text(
+                '${_scanResults.length} found',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+
+        // Visible networks
+        ...visibleNetworks.map(
+          (network) => _WifiNetworkTile(
+            network: network,
+            onTap: () => _showConnectDialog(network),
+          ),
+        ),
+
+        // Hidden networks section
+        if (hiddenNetworks.isNotEmpty) ...[
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              LuciSpacing.md,
+              LuciSpacing.md,
+              LuciSpacing.md,
+              LuciSpacing.sm,
+            ),
+            child: Text(
+              'HIDDEN NETWORKS',
+              style: LuciTextStyles.sectionHeader(context),
+            ),
+          ),
+          ...hiddenNetworks.map(
+            (network) => _WifiNetworkTile(
+              network: network,
+              onTap: () => _showConnectDialog(network),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// WiFi Network List Tile
+// ──────────────────────────────────────────────────────────────────
+
+class _WifiNetworkTile extends StatelessWidget {
+  final WifiScanResult network;
+  final VoidCallback onTap;
+
+  const _WifiNetworkTile({required this.network, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final signalColor = _getSignalColor(colorScheme);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: LuciSpacing.md,
+        vertical: 4,
+      ),
+      child: Card(
+        elevation: 1,
+        margin: EdgeInsets.zero,
+        shape: RoundedRectangleBorder(
+          borderRadius: LuciCardStyles.standardRadius,
+          side: BorderSide(
+            color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.10),
+            width: 1,
+          ),
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: LuciCardStyles.standardRadius,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: LuciSpacing.md,
+              vertical: 12,
+            ),
+            child: Row(
+              children: [
+                // Signal strength icon
+                _SignalIcon(
+                  bars: network.signalBars,
+                  color: signalColor,
+                  hasLock: network.encryption.enabled,
+                ),
+                const SizedBox(width: 14),
+
+                // Network info
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        network.ssid.isNotEmpty
+                            ? network.ssid
+                            : '(Hidden Network)',
+                        style: LuciTextStyles.cardTitle(context).copyWith(
+                          fontStyle: network.ssid.isEmpty
+                              ? FontStyle.italic
+                              : FontStyle.normal,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        '${network.band} • Ch. ${network.channel} • ${network.signal} dBm',
+                        style: LuciTextStyles.cardSubtitle(context),
+                      ),
+                    ],
+                  ),
+                ),
+
+                // Encryption badge
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 4,
+                  ),
+                  decoration: BoxDecoration(
+                    color: network.encryption.isOpen
+                        ? colorScheme.errorContainer.withValues(alpha: 0.3)
+                        : colorScheme.primaryContainer.withValues(alpha: 0.3),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    network.encryption.shortLabel,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: network.encryption.isOpen
+                          ? colorScheme.error
+                          : colorScheme.primary,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+
+                const SizedBox(width: 4),
+                Icon(
+                  Icons.chevron_right,
+                  color: colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+                  size: 20,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Color _getSignalColor(ColorScheme colorScheme) {
+    if (network.signal >= -50) return Colors.green;
+    if (network.signal >= -60) return Colors.lightGreen;
+    if (network.signal >= -70) return Colors.orange;
+    if (network.signal >= -80) return Colors.deepOrange;
+    return colorScheme.error;
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Signal strength icon with bars
+// ──────────────────────────────────────────────────────────────────
+
+class _SignalIcon extends StatelessWidget {
+  final int bars;
+  final Color color;
+  final bool hasLock;
+
+  const _SignalIcon({
+    required this.bars,
+    required this.color,
+    required this.hasLock,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return SizedBox(
+      width: 36,
+      height: 36,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          Container(
+            width: 36,
+            height: 36,
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.12),
+              shape: BoxShape.circle,
+            ),
+          ),
+          // Use built-in WiFi icons based on signal level
+          Icon(
+            _getWifiIcon(),
+            size: 22,
+            color: color,
+          ),
+          // Lock indicator
+          if (hasLock)
+            Positioned(
+              right: 0,
+              bottom: 0,
+              child: Container(
+                width: 14,
+                height: 14,
+                decoration: BoxDecoration(
+                  color: colorScheme.surface,
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(
+                  Icons.lock,
+                  size: 10,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  IconData _getWifiIcon() {
+    switch (bars) {
+      case 4:
+        return Icons.wifi;
+      case 3:
+        return Icons.wifi;
+      case 2:
+        return Icons.wifi_2_bar;
+      case 1:
+        return Icons.wifi_1_bar;
+      default:
+        return Icons.wifi_1_bar;
+    }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Connect Bottom Sheet
+// ──────────────────────────────────────────────────────────────────
+
+class _ConnectBottomSheet extends ConsumerStatefulWidget {
+  final WifiScanResult network;
+  final List<Map<String, String>> radioDevices;
+  final String? selectedDevice;
+
+  const _ConnectBottomSheet({
+    required this.network,
+    required this.radioDevices,
+    this.selectedDevice,
+  });
+
+  @override
+  ConsumerState<_ConnectBottomSheet> createState() =>
+      _ConnectBottomSheetState();
+}
+
+class _ConnectBottomSheetState extends ConsumerState<_ConnectBottomSheet> {
+  final _passwordController = TextEditingController();
+  bool _obscurePassword = true;
+  bool _isConnecting = false;
+  String? _selectedRadio;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    // Default to the radio that was used for scanning
+    if (widget.selectedDevice != null && widget.radioDevices.isNotEmpty) {
+      // selectedDevice is now a radioName directly
+      _selectedRadio = widget.selectedDevice;
+    } else if (widget.radioDevices.isNotEmpty) {
+      _selectedRadio = widget.radioDevices.first['radioName'];
+    }
+  }
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _connect() async {
+    if (_selectedRadio == null) {
+      setState(() {
+        _error = 'Please select a radio device.';
+      });
+      return;
+    }
+
+    if (widget.network.encryption.requiresPassword &&
+        _passwordController.text.isEmpty) {
+      setState(() {
+        _error = 'Password is required for this network.';
+      });
+      return;
+    }
+
+    // WPA2 requires minimum 8 characters
+    if (widget.network.encryption.requiresPassword &&
+        !widget.network.encryption.wep &&
+        _passwordController.text.length < 8) {
+      setState(() {
+        _error = 'Password must be at least 8 characters.';
+      });
+      return;
+    }
+
+    setState(() {
+      _isConnecting = true;
+      _error = null;
+    });
+
+    final appState = ref.read(appStateProvider);
+    final success = await appState.connectToWirelessNetwork(
+      radioDevice: _selectedRadio!,
+      ssid: widget.network.ssid,
+      encryption: widget.network.encryption.openwrtEncryption,
+      password: _passwordController.text,
+      bssid: widget.network.bssid,
+      context: context,
+    );
+
+    if (!mounted) return;
+
+    if (success) {
+      Navigator.of(context).pop();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Row(
+            children: [
+              const Icon(Icons.check_circle, color: Colors.white, size: 20),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Connecting to "${widget.network.ssid}"...',
+                ),
+              ),
+            ],
+          ),
+          backgroundColor: Colors.green.shade700,
+          behavior: SnackBarBehavior.floating,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10),
+          ),
+          duration: const Duration(seconds: 4),
+        ),
+      );
+    } else {
+      setState(() {
+        _isConnecting = false;
+        _error = 'Failed to connect. Check your password and try again.';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final network = widget.network;
+
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(
+            LuciSpacing.lg,
+            LuciSpacing.md,
+            LuciSpacing.lg,
+            LuciSpacing.lg,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Drag handle
+              Center(
+                child: Container(
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: colorScheme.onSurfaceVariant.withValues(alpha: 0.3),
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ),
+              const SizedBox(height: LuciSpacing.lg),
+
+              // Network header
+              Row(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: colorScheme.primaryContainer.withValues(alpha: 0.3),
+                      shape: BoxShape.circle,
+                    ),
+                    child: Icon(
+                      Icons.wifi,
+                      color: colorScheme.primary,
+                      size: 28,
+                    ),
+                  ),
+                  const SizedBox(width: LuciSpacing.md),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          network.ssid.isNotEmpty
+                              ? network.ssid
+                              : '(Hidden Network)',
+                          style: theme.textTheme.titleLarge?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          '${network.encryption.shortLabel} • ${network.band} • Ch. ${network.channel}',
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+
+              const SizedBox(height: LuciSpacing.lg),
+
+              // Network details
+              _buildInfoRow(
+                context,
+                'BSSID',
+                network.bssid,
+                Icons.router_outlined,
+              ),
+              _buildInfoRow(
+                context,
+                'Signal',
+                '${network.signal} dBm (${network.signalStrength})',
+                Icons.signal_cellular_alt,
+              ),
+              _buildInfoRow(
+                context,
+                'Encryption',
+                network.encryption.description,
+                Icons.security,
+              ),
+
+              const SizedBox(height: LuciSpacing.lg),
+              Divider(
+                color: colorScheme.outlineVariant.withValues(alpha: 0.5),
+              ),
+              const SizedBox(height: LuciSpacing.md),
+
+              // Radio selector
+              Text(
+                'Connect using radio:',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: LuciSpacing.sm),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(
+                    color: colorScheme.outline.withValues(alpha: 0.3),
+                  ),
+                  color: colorScheme.surfaceContainerLow,
+                ),
+                child: DropdownButtonHideUnderline(
+                  child: DropdownButton<String>(
+                    value: _selectedRadio,
+                    isExpanded: true,
+                    icon: Icon(
+                      Icons.arrow_drop_down,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                    items: widget.radioDevices.map((device) {
+                      final radioName = device['radioName'] ?? '';
+                      final band = device['band'] ?? '';
+                      final label = band.isNotEmpty
+                          ? '$radioName ($band)'
+                          : radioName;
+                      return DropdownMenuItem<String>(
+                        value: device['radioName'],
+                        child: Text(
+                          label,
+                          style: theme.textTheme.bodyMedium,
+                        ),
+                      );
+                    }).toList(),
+                    onChanged: _isConnecting
+                        ? null
+                        : (value) {
+                            setState(() {
+                              _selectedRadio = value;
+                            });
+                          },
+                  ),
+                ),
+              ),
+
+              // Password field (only for encrypted networks)
+              if (network.encryption.requiresPassword) ...[
+                const SizedBox(height: LuciSpacing.md),
+                Text(
+                  'Password:',
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: LuciSpacing.sm),
+                TextField(
+                  controller: _passwordController,
+                  obscureText: _obscurePassword,
+                  enabled: !_isConnecting,
+                  decoration: InputDecoration(
+                    hintText: 'Enter network password',
+                    prefixIcon: const Icon(Icons.key),
+                    suffixIcon: IconButton(
+                      icon: Icon(
+                        _obscurePassword
+                            ? Icons.visibility_off
+                            : Icons.visibility,
+                      ),
+                      onPressed: () {
+                        setState(() {
+                          _obscurePassword = !_obscurePassword;
+                        });
+                      },
+                    ),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide(
+                        color: colorScheme.outline.withValues(alpha: 0.3),
+                      ),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide(
+                        color: colorScheme.primary,
+                        width: 2,
+                      ),
+                    ),
+                    filled: true,
+                    fillColor: colorScheme.surfaceContainerLow,
+                  ),
+                  onSubmitted: (_) => _connect(),
+                ),
+              ],
+
+              // Error message
+              if (_error != null) ...[
+                const SizedBox(height: LuciSpacing.sm),
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: colorScheme.errorContainer.withValues(alpha: 0.3),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Row(
+                    children: [
+                      Icon(
+                        Icons.error_outline,
+                        color: colorScheme.error,
+                        size: 18,
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          _error!,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: colorScheme.error,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+
+              const SizedBox(height: LuciSpacing.lg),
+
+              // Warning for station mode
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: colorScheme.tertiaryContainer.withValues(alpha: 0.2),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Icon(
+                      Icons.info_outline,
+                      color: colorScheme.tertiary,
+                      size: 18,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        'This will create a new station-mode (client) interface on the selected radio. The radio will connect to this network as a client.',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: colorScheme.onSurface.withValues(alpha: 0.7),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              const SizedBox(height: LuciSpacing.lg),
+
+              // Connect button
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: _isConnecting ? null : _connect,
+                  icon: _isConnecting
+                      ? SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: colorScheme.onPrimary,
+                          ),
+                        )
+                      : const Icon(Icons.wifi),
+                  label: Text(
+                    _isConnecting ? 'Connecting...' : 'Connect',
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  style: FilledButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(14),
+                    ),
+                  ),
+                ),
+              ),
+
+              const SizedBox(height: LuciSpacing.sm),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(
+    BuildContext context,
+    String label,
+    String value,
+    IconData icon,
+  ) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          Icon(icon, size: 16, color: colorScheme.onSurfaceVariant),
+          const SizedBox(width: 10),
+          SizedBox(
+            width: 80,
+            child: Text(
+              label,
+              style: LuciTextStyles.detailLabel(context),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: LuciTextStyles.detailValue(context),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/wifi_scan_screen.dart
+++ b/lib/screens/wifi_scan_screen.dart
@@ -54,6 +54,7 @@ class _WifiScanScreenState extends ConsumerState<WifiScanScreen>
   }
 
   void _loadRadioDevices() {
+    if (!mounted) return;
     final appState = ref.read(appStateProvider);
     final devices = appState.getAvailableRadioDevices();
     setState(() {

--- a/lib/screens/wifi_scan_screen.dart
+++ b/lib/screens/wifi_scan_screen.dart
@@ -215,8 +215,8 @@ class _WifiScanScreenState extends ConsumerState<WifiScanScreen>
             child: _isScanning
                 ? _buildScanningIndicator(theme, colorScheme)
                 : _scanResults.isEmpty
-                    ? _buildEmptyState(theme, colorScheme)
-                    : _buildResultsList(theme, colorScheme),
+                ? _buildEmptyState(theme, colorScheme)
+                : _buildResultsList(theme, colorScheme),
           ),
         ],
       ),
@@ -363,7 +363,8 @@ class _WifiScanScreenState extends ConsumerState<WifiScanScreen>
               // Restart Radio button
               Expanded(
                 child: OutlinedButton.icon(
-                  onPressed: _isScanning || _isRestarting || _selectedRadio == null
+                  onPressed:
+                      _isScanning || _isRestarting || _selectedRadio == null
                       ? null
                       : _restartRadio,
                   icon: _isRestarting
@@ -376,7 +377,9 @@ class _WifiScanScreenState extends ConsumerState<WifiScanScreen>
                           ),
                         )
                       : const Icon(Icons.restart_alt, size: 20),
-                  label: Text(_isRestarting ? 'Restarting...' : 'Restart Radio'),
+                  label: Text(
+                    _isRestarting ? 'Restarting...' : 'Restart Radio',
+                  ),
                   style: OutlinedButton.styleFrom(
                     padding: const EdgeInsets.symmetric(vertical: 12),
                     side: BorderSide(
@@ -446,7 +449,9 @@ class _WifiScanScreenState extends ConsumerState<WifiScanScreen>
                     height: 80,
                     decoration: BoxDecoration(
                       shape: BoxShape.circle,
-                      color: colorScheme.primaryContainer.withValues(alpha: 0.3),
+                      color: colorScheme.primaryContainer.withValues(
+                        alpha: 0.3,
+                      ),
                     ),
                     child: Icon(
                       Icons.radar,
@@ -490,7 +495,8 @@ class _WifiScanScreenState extends ConsumerState<WifiScanScreen>
           ),
           const SizedBox(height: LuciSpacing.md),
           Text(
-            _error ?? 'Select a radio and tap Scan\nto find nearby WiFi networks',
+            _error ??
+                'Select a radio and tap Scan\nto find nearby WiFi networks',
             textAlign: TextAlign.center,
             style: theme.textTheme.bodyLarge?.copyWith(
               color: _error != null
@@ -515,10 +521,10 @@ class _WifiScanScreenState extends ConsumerState<WifiScanScreen>
 
   Widget _buildResultsList(ThemeData theme, ColorScheme colorScheme) {
     // Separate networks with SSIDs from hidden ones
-    final visibleNetworks =
-        _scanResults.where((r) => r.ssid.isNotEmpty).toList();
-    final hiddenNetworks =
-        _scanResults.where((r) => r.ssid.isEmpty).toList();
+    final visibleNetworks = _scanResults
+        .where((r) => r.ssid.isNotEmpty)
+        .toList();
+    final hiddenNetworks = _scanResults.where((r) => r.ssid.isEmpty).toList();
 
     return ListView(
       padding: const EdgeInsets.symmetric(vertical: LuciSpacing.sm),
@@ -734,11 +740,7 @@ class _SignalIcon extends StatelessWidget {
             ),
           ),
           // Use built-in WiFi icons based on signal level
-          Icon(
-            _getWifiIcon(),
-            size: 22,
-            color: color,
-          ),
+          Icon(_getWifiIcon(), size: 22, color: color),
           // Lock indicator
           if (hasLock)
             Positioned(
@@ -847,7 +849,8 @@ class _ConnectBottomSheetState extends ConsumerState<_ConnectBottomSheet> {
     // Block unsupported enterprise networks.
     if (widget.network.encryption.isEnterprise) {
       setState(() {
-        _error = 'Enterprise (EAP) networks are not supported for connecting here.';
+        _error =
+            'Enterprise (EAP) networks are not supported for connecting here.';
       });
       return;
     }
@@ -900,11 +903,7 @@ class _ConnectBottomSheetState extends ConsumerState<_ConnectBottomSheet> {
             children: [
               const Icon(Icons.check_circle, color: Colors.white, size: 20),
               const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  'Connecting to "${widget.network.ssid}"...',
-                ),
-              ),
+              Expanded(child: Text('Connecting to "$ssid"...')),
             ],
           ),
           backgroundColor: Colors.green.shade700,
@@ -964,7 +963,9 @@ class _ConnectBottomSheetState extends ConsumerState<_ConnectBottomSheet> {
                   Container(
                     padding: const EdgeInsets.all(12),
                     decoration: BoxDecoration(
-                      color: colorScheme.primaryContainer.withValues(alpha: 0.3),
+                      color: colorScheme.primaryContainer.withValues(
+                        alpha: 0.3,
+                      ),
                       shape: BoxShape.circle,
                     ),
                     child: Icon(
@@ -1022,9 +1023,7 @@ class _ConnectBottomSheetState extends ConsumerState<_ConnectBottomSheet> {
               ),
 
               const SizedBox(height: LuciSpacing.lg),
-              Divider(
-                color: colorScheme.outlineVariant.withValues(alpha: 0.5),
-              ),
+              Divider(color: colorScheme.outlineVariant.withValues(alpha: 0.5)),
               const SizedBox(height: LuciSpacing.md),
 
               // Radio selector
@@ -1060,10 +1059,7 @@ class _ConnectBottomSheetState extends ConsumerState<_ConnectBottomSheet> {
                           : radioName;
                       return DropdownMenuItem<String>(
                         value: device['radioName'],
-                        child: Text(
-                          label,
-                          style: theme.textTheme.bodyMedium,
-                        ),
+                        child: Text(label, style: theme.textTheme.bodyMedium),
                       );
                     }).toList(),
                     onChanged: _isConnecting
@@ -1275,10 +1271,7 @@ class _ConnectBottomSheetState extends ConsumerState<_ConnectBottomSheet> {
           const SizedBox(width: 10),
           SizedBox(
             width: 80,
-            child: Text(
-              label,
-              style: LuciTextStyles.detailLabel(context),
-            ),
+            child: Text(label, style: LuciTextStyles.detailLabel(context)),
           ),
           Expanded(
             child: Text(

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -886,7 +886,8 @@ class RealApiService implements IApiService {
     BuildContext? context,
   }) async {
     cancelScan();
-    _scanCancelToken = CancelToken();
+    final scanToken = CancelToken();
+    _scanCancelToken = scanToken;
 
     Logger.info('WiFi scan starting on device: $device');
 
@@ -900,9 +901,8 @@ class RealApiService implements IApiService {
         params: {'device': device},
         context: context,
         receiveTimeout: const Duration(seconds: 120),
-        cancelToken: _scanCancelToken,
+        cancelToken: scanToken,
       );
-      _scanCancelToken = null;
 
       Logger.info('WiFi scan raw result type: ${result.runtimeType}');
 
@@ -961,6 +961,10 @@ class RealApiService implements IApiService {
       }
       Logger.exception('WiFi scan DioException', e, e.stackTrace);
       rethrow;
+    } finally {
+      if (identical(_scanCancelToken, scanToken)) {
+        _scanCancelToken = null;
+      }
     }
   }
 

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -414,6 +414,26 @@ class RealApiService implements IApiService {
     required String method,
     Map<String, dynamic>? params,
     BuildContext? context,
+  }) {
+    return _callWithTransport(
+      ipAddress,
+      sysauth,
+      useHttps,
+      object: object,
+      method: method,
+      params: params,
+      context: context,
+    );
+  }
+
+  Future<dynamic> _callWithTransport(
+    String ipAddress,
+    String sysauth,
+    bool useHttps, {
+    required String object,
+    required String method,
+    Map<String, dynamic>? params,
+    BuildContext? context,
     Duration? receiveTimeout,
     CancelToken? cancelToken,
   }) async {
@@ -871,7 +891,7 @@ class RealApiService implements IApiService {
     Logger.info('WiFi scan starting on device: $device');
 
     try {
-      final result = await callWithContext(
+      final result = await _callWithTransport(
         ipAddress,
         sysauth,
         useHttps,

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -408,6 +408,8 @@ class RealApiService implements IApiService {
     required String method,
     Map<String, dynamic>? params,
     BuildContext? context,
+    Duration? receiveTimeout,
+    CancelToken? cancelToken,
   }) async {
     final url = _buildUrl(ipAddress, useHttps, '/cgi-bin/luci/admin/ubus');
     final client = _createHttpClient(useHttps, ipAddress, context: context);
@@ -423,7 +425,11 @@ class RealApiService implements IApiService {
       final response = await client.post(
         url.toString(),
         data: jsonEncode(rpcPayload),
-        options: Options(headers: {'Content-Type': 'application/json'}),
+        cancelToken: cancelToken,
+        options: Options(
+          headers: {'Content-Type': 'application/json'},
+          receiveTimeout: receiveTimeout,
+        ),
       );
 
       if (response.statusCode == 200) {
@@ -817,6 +823,169 @@ class RealApiService implements IApiService {
       object: 'file',
       method: 'exec',
       params: {'command': command, 'params': params},
+      context: context,
+    );
+  }
+
+  CancelToken? _scanCancelToken;
+
+  @override
+  void cancelScan() {
+    _scanCancelToken?.cancel('Scan cancelled by user');
+    _scanCancelToken = null;
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> scanWirelessNetworks({
+    required String ipAddress,
+    required String sysauth,
+    required bool useHttps,
+    required String device,
+    BuildContext? context,
+  }) async {
+    cancelScan();
+    _scanCancelToken = CancelToken();
+
+    Logger.info('WiFi scan starting on device: $device');
+
+    try {
+      final result = await callWithContext(
+        ipAddress,
+        sysauth,
+        useHttps,
+        object: 'iwinfo',
+        method: 'scan',
+        params: {'device': device},
+        context: context,
+        receiveTimeout: const Duration(seconds: 120),
+        cancelToken: _scanCancelToken,
+      );
+      _scanCancelToken = null;
+
+      Logger.info('WiFi scan raw result type: ${result.runtimeType}');
+
+      if (result is List) {
+        final statusCode = result.isNotEmpty ? result[0] : null;
+        if (statusCode != null && statusCode != 0) {
+          const ubusErrors = {
+            1: 'Invalid command',
+            2: 'Invalid argument',
+            3: 'Method not found',
+            4: 'Not found',
+            5: 'No data',
+            6: 'Permission denied',
+            7: 'Request timed out',
+          };
+          final errMsg = ubusErrors[statusCode] ?? 'Unknown error';
+          throw Exception(
+            'iwinfo scan failed: $errMsg (code $statusCode) on device "$device"',
+          );
+        }
+
+        if (result.length < 2 || result[1] == null) return [];
+
+        final data = result[1];
+        if (data is Map) {
+          if (data['results'] is List) {
+            return (data['results'] as List)
+                .whereType<Map<String, dynamic>>()
+                .toList();
+          }
+          for (final value in data.values) {
+            if (value is List && value.isNotEmpty && value.first is Map) {
+              return value.whereType<Map<String, dynamic>>().toList();
+            }
+          }
+          Logger.warning(
+            'WiFi scan: response is Map but no results. Keys: ${data.keys.toList()}',
+          );
+          return [];
+        }
+
+        if (data is List) {
+          return data.whereType<Map<String, dynamic>>().toList();
+        }
+
+        Logger.warning('WiFi scan: unexpected data type: ${data.runtimeType}');
+        return [];
+      }
+
+      Logger.warning('WiFi scan: result is not List: ${result.runtimeType}');
+      return [];
+    } on DioException catch (e) {
+      if (e.type == DioExceptionType.cancel) return [];
+      if (e.type == DioExceptionType.receiveTimeout) {
+        throw Exception(
+          'Scan timed out on "$device". The radio may be busy.',
+        );
+      }
+      Logger.exception('WiFi scan DioException', e, e.stackTrace);
+      rethrow;
+    }
+  }
+
+  @override
+  Future<dynamic> uciAdd(
+    String ipAddress,
+    String sysauth,
+    bool useHttps, {
+    required String config,
+    required String type,
+    required Map<String, dynamic> values,
+    String? name,
+    BuildContext? context,
+  }) async {
+    return await callWithContext(
+      ipAddress,
+      sysauth,
+      useHttps,
+      object: 'uci',
+      method: 'add',
+      params: {
+        'config': config,
+        'type': type,
+        'values': values,
+        if (name != null) 'name': name,
+      },
+      context: context,
+    );
+  }
+
+  @override
+  Future<dynamic> uciDelete(
+    String ipAddress,
+    String sysauth,
+    bool useHttps, {
+    required String config,
+    required String section,
+    BuildContext? context,
+  }) async {
+    return await callWithContext(
+      ipAddress,
+      sysauth,
+      useHttps,
+      object: 'uci',
+      method: 'delete',
+      params: {'config': config, 'section': section},
+      context: context,
+    );
+  }
+
+  @override
+  Future<dynamic> uciGetAll(
+    String ipAddress,
+    String sysauth,
+    bool useHttps, {
+    required String config,
+    BuildContext? context,
+  }) async {
+    return await callWithContext(
+      ipAddress,
+      sysauth,
+      useHttps,
+      object: 'uci',
+      method: 'get',
+      params: {'config': config},
       context: context,
     );
   }

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -152,6 +152,12 @@ String? _extractSysauthToken(Headers headers) {
 class RealApiService implements IApiService {
   final HttpClientManager _httpClientManager = HttpClientManager();
 
+  List<dynamic> _requireRpcSuccess(dynamic result, String operation) {
+    if (result is List && result.isNotEmpty && result[0] == 0) return result;
+    final detail = result is List && result.length > 1 ? result[1] : result;
+    throw Exception('$operation failed: $detail');
+  }
+
   Dio _createHttpClient(
     bool useHttps,
     String hostWithPort, {
@@ -772,14 +778,17 @@ class RealApiService implements IApiService {
     required Map<String, String> values,
     BuildContext? context,
   }) async {
-    return await callWithContext(
-      ipAddress,
-      sysauth,
-      useHttps,
-      object: 'uci',
-      method: 'set',
-      params: {'config': config, 'section': section, 'values': values},
-      context: context,
+    return _requireRpcSuccess(
+      await callWithContext(
+        ipAddress,
+        sysauth,
+        useHttps,
+        object: 'uci',
+        method: 'set',
+        params: {'config': config, 'section': section, 'values': values},
+        context: context,
+      ),
+      'uci.set',
     );
   }
 
@@ -791,14 +800,17 @@ class RealApiService implements IApiService {
     required String config,
     BuildContext? context,
   }) async {
-    return await callWithContext(
-      ipAddress,
-      sysauth,
-      useHttps,
-      object: 'uci',
-      method: 'commit',
-      params: {'config': config},
-      context: context,
+    return _requireRpcSuccess(
+      await callWithContext(
+        ipAddress,
+        sysauth,
+        useHttps,
+        object: 'uci',
+        method: 'commit',
+        params: {'config': config},
+        context: context,
+      ),
+      'uci.commit',
     );
   }
 
@@ -816,15 +828,25 @@ class RealApiService implements IApiService {
     List<String> params = const [],
     BuildContext? context,
   }) async {
-    return await callWithContext(
-      ipAddress,
-      sysauth,
-      useHttps,
-      object: 'file',
-      method: 'exec',
-      params: {'command': command, 'params': params},
-      context: context,
+    final result = _requireRpcSuccess(
+      await callWithContext(
+        ipAddress,
+        sysauth,
+        useHttps,
+        object: 'file',
+        method: 'exec',
+        params: {'command': command, 'params': params},
+        context: context,
+      ),
+      'file.exec',
     );
+    final data = result.length > 1 ? result[1] : null;
+    if (data is Map && data['code'] is num && data['code'] != 0) {
+      throw Exception(
+        'file.exec failed: ${data['stderr'] ?? 'exit ${data['code']}'}',
+      );
+    }
+    return result;
   }
 
   CancelToken? _scanCancelToken;
@@ -915,9 +937,7 @@ class RealApiService implements IApiService {
     } on DioException catch (e) {
       if (e.type == DioExceptionType.cancel) return [];
       if (e.type == DioExceptionType.receiveTimeout) {
-        throw Exception(
-          'Scan timed out on "$device". The radio may be busy.',
-        );
+        throw Exception('Scan timed out on "$device". The radio may be busy.');
       }
       Logger.exception('WiFi scan DioException', e, e.stackTrace);
       rethrow;
@@ -935,19 +955,22 @@ class RealApiService implements IApiService {
     String? name,
     BuildContext? context,
   }) async {
-    return await callWithContext(
-      ipAddress,
-      sysauth,
-      useHttps,
-      object: 'uci',
-      method: 'add',
-      params: {
-        'config': config,
-        'type': type,
-        'values': values,
-        if (name != null) 'name': name,
-      },
-      context: context,
+    return _requireRpcSuccess(
+      await callWithContext(
+        ipAddress,
+        sysauth,
+        useHttps,
+        object: 'uci',
+        method: 'add',
+        params: {
+          'config': config,
+          'type': type,
+          'values': values,
+          'name': ?name,
+        },
+        context: context,
+      ),
+      'uci.add',
     );
   }
 
@@ -958,16 +981,20 @@ class RealApiService implements IApiService {
     bool useHttps, {
     required String config,
     required String section,
+    String? option,
     BuildContext? context,
   }) async {
-    return await callWithContext(
-      ipAddress,
-      sysauth,
-      useHttps,
-      object: 'uci',
-      method: 'delete',
-      params: {'config': config, 'section': section},
-      context: context,
+    return _requireRpcSuccess(
+      await callWithContext(
+        ipAddress,
+        sysauth,
+        useHttps,
+        object: 'uci',
+        method: 'delete',
+        params: {'config': config, 'section': section, 'option': ?option},
+        context: context,
+      ),
+      'uci.delete',
     );
   }
 
@@ -979,14 +1006,17 @@ class RealApiService implements IApiService {
     required String config,
     BuildContext? context,
   }) async {
-    return await callWithContext(
-      ipAddress,
-      sysauth,
-      useHttps,
-      object: 'uci',
-      method: 'get',
-      params: {'config': config},
-      context: context,
+    return _requireRpcSuccess(
+      await callWithContext(
+        ipAddress,
+        sysauth,
+        useHttps,
+        object: 'uci',
+        method: 'get',
+        params: {'config': config},
+        context: context,
+      ),
+      'uci.get',
     );
   }
 }

--- a/lib/services/interfaces/api_service_interface.dart
+++ b/lib/services/interfaces/api_service_interface.dart
@@ -113,13 +113,14 @@ abstract class IApiService {
     BuildContext? context,
   });
 
-  /// Deletes a UCI section (e.g., to remove a wifi-iface).
+  /// Deletes a UCI section or one of its options.
   Future<dynamic> uciDelete(
     String ipAddress,
     String sysauth,
     bool useHttps, {
     required String config,
     required String section,
+    String? option,
     BuildContext? context,
   });
 

--- a/lib/services/interfaces/api_service_interface.dart
+++ b/lib/services/interfaces/api_service_interface.dart
@@ -86,4 +86,49 @@ abstract class IApiService {
     List<String> params = const [],
     BuildContext? context,
   });
+
+  /// Scans for nearby wireless networks using a given radio device (e.g., wlan0).
+  /// Returns the raw scan results from iwinfo.scan.
+  Future<List<Map<String, dynamic>>> scanWirelessNetworks({
+    required String ipAddress,
+    required String sysauth,
+    required bool useHttps,
+    required String device,
+    BuildContext? context,
+  });
+
+  /// Cancel any ongoing wireless network scan.
+  void cancelScan() {}
+
+  /// Adds a new UCI section. If [name] is provided, creates a named section;
+  /// otherwise creates an anonymous section.
+  Future<dynamic> uciAdd(
+    String ipAddress,
+    String sysauth,
+    bool useHttps, {
+    required String config,
+    required String type,
+    required Map<String, dynamic> values,
+    String? name,
+    BuildContext? context,
+  });
+
+  /// Deletes a UCI section (e.g., to remove a wifi-iface).
+  Future<dynamic> uciDelete(
+    String ipAddress,
+    String sysauth,
+    bool useHttps, {
+    required String config,
+    required String section,
+    BuildContext? context,
+  });
+
+  /// Retrieves the full UCI config for a given config name.
+  Future<dynamic> uciGetAll(
+    String ipAddress,
+    String sysauth,
+    bool useHttps, {
+    required String config,
+    BuildContext? context,
+  });
 }

--- a/lib/services/mock_api_service.dart
+++ b/lib/services/mock_api_service.dart
@@ -12,6 +12,8 @@ class MockApiService implements IApiService {
   static int _baseTxBytes = 987654321;
   static int _baseRxPackets = 12345;
   static int _baseTxPackets = 9876;
+  // Scan cancellation token — incremented by cancelScan().
+  int _scanToken = 0;
   static int _baseLanRxBytes = 2345678901;
   static int _baseLanTxBytes = 1876543210;
   static int _baseLanRxPackets = 23456;
@@ -914,7 +916,10 @@ class MockApiService implements IApiService {
     required String device,
     BuildContext? context,
   }) async {
+    final token = _scanToken;
     await Future.delayed(const Duration(seconds: 2)); // Simulate scan time
+    // Return empty list if scan was cancelled before completion.
+    if (_scanToken != token) return [];
     return [
       {
         'ssid': 'Neighbor-WiFi',
@@ -1077,5 +1082,7 @@ class MockApiService implements IApiService {
   }
 
   @override
-  void cancelScan() {}
+  void cancelScan() {
+    _scanToken++; // invalidates any in-flight scan
+  }
 }

--- a/lib/services/mock_api_service.dart
+++ b/lib/services/mock_api_service.dart
@@ -905,4 +905,177 @@ class MockApiService implements IApiService {
     // For mock service, just delegate to fetchAssociatedStations
     return await fetchAssociatedStations();
   }
+
+  @override
+  Future<List<Map<String, dynamic>>> scanWirelessNetworks({
+    required String ipAddress,
+    required String sysauth,
+    required bool useHttps,
+    required String device,
+    BuildContext? context,
+  }) async {
+    await Future.delayed(const Duration(seconds: 2)); // Simulate scan time
+    return [
+      {
+        'ssid': 'Neighbor-WiFi',
+        'bssid': 'AA:BB:CC:11:22:33',
+        'mode': 'Master',
+        'channel': 1,
+        'signal': -45,
+        'quality': 65,
+        'quality_max': 70,
+        'encryption': {
+          'enabled': true,
+          'description': 'WPA2 PSK (CCMP)',
+          'wep': false,
+          'wpa': 2,
+          'auth_suites': ['PSK'],
+          'pair_ciphers': ['CCMP'],
+          'group_ciphers': ['CCMP'],
+        },
+      },
+      {
+        'ssid': 'CoffeeShop-Free',
+        'bssid': 'DD:EE:FF:44:55:66',
+        'mode': 'Master',
+        'channel': 6,
+        'signal': -62,
+        'quality': 48,
+        'quality_max': 70,
+        'encryption': {
+          'enabled': false,
+          'description': 'None',
+          'wep': false,
+          'wpa': 0,
+          'auth_suites': <String>[],
+          'pair_ciphers': <String>[],
+          'group_ciphers': <String>[],
+        },
+      },
+      {
+        'ssid': 'Office-5G',
+        'bssid': '11:22:33:AA:BB:CC',
+        'mode': 'Master',
+        'channel': 36,
+        'signal': -55,
+        'quality': 55,
+        'quality_max': 70,
+        'encryption': {
+          'enabled': true,
+          'description': 'WPA2 PSK (CCMP)',
+          'wep': false,
+          'wpa': 2,
+          'auth_suites': ['PSK'],
+          'pair_ciphers': ['CCMP'],
+          'group_ciphers': ['CCMP'],
+        },
+      },
+      {
+        'ssid': 'SmartHome-IoT',
+        'bssid': '77:88:99:DD:EE:FF',
+        'mode': 'Master',
+        'channel': 11,
+        'signal': -71,
+        'quality': 35,
+        'quality_max': 70,
+        'encryption': {
+          'enabled': true,
+          'description': 'WPA3 SAE (CCMP)',
+          'wep': false,
+          'wpa': 3,
+          'auth_suites': ['SAE'],
+          'pair_ciphers': ['CCMP'],
+          'group_ciphers': ['CCMP'],
+        },
+      },
+      {
+        'ssid': 'NETGEAR-Guest',
+        'bssid': 'CC:DD:EE:11:22:33',
+        'mode': 'Master',
+        'channel': 44,
+        'signal': -78,
+        'quality': 22,
+        'quality_max': 70,
+        'encryption': {
+          'enabled': true,
+          'description': 'WPA2 PSK (CCMP)',
+          'wep': false,
+          'wpa': 2,
+          'auth_suites': ['PSK'],
+          'pair_ciphers': ['CCMP'],
+          'group_ciphers': ['CCMP'],
+        },
+      },
+      {
+        'ssid': '',
+        'bssid': 'FF:00:11:22:33:44',
+        'mode': 'Master',
+        'channel': 3,
+        'signal': -82,
+        'quality': 15,
+        'quality_max': 70,
+        'encryption': {
+          'enabled': true,
+          'description': 'WPA2 PSK (CCMP)',
+          'wep': false,
+          'wpa': 2,
+          'auth_suites': ['PSK'],
+          'pair_ciphers': ['CCMP'],
+          'group_ciphers': ['CCMP'],
+        },
+      },
+    ];
+  }
+
+  @override
+  Future<dynamic> uciAdd(
+    String ipAddress,
+    String sysauth,
+    bool useHttps, {
+    required String config,
+    required String type,
+    required Map<String, dynamic> values,
+    String? name,
+    BuildContext? context,
+  }) async {
+    await Future.delayed(const Duration(milliseconds: 300));
+    return [0, name ?? 'cfg_new_section'];
+  }
+
+  @override
+  Future<dynamic> uciDelete(
+    String ipAddress,
+    String sysauth,
+    bool useHttps, {
+    required String config,
+    required String section,
+    BuildContext? context,
+  }) async {
+    await Future.delayed(const Duration(milliseconds: 200));
+    return [0, 'success'];
+  }
+
+  @override
+  Future<dynamic> uciGetAll(
+    String ipAddress,
+    String sysauth,
+    bool useHttps, {
+    required String config,
+    BuildContext? context,
+  }) async {
+    await Future.delayed(const Duration(milliseconds: 200));
+    // Just reuse the call method for uci.get
+    return await call(
+      ipAddress,
+      sysauth,
+      useHttps,
+      object: 'uci',
+      method: 'get',
+      params: {'config': config},
+      context: context,
+    );
+  }
+
+  @override
+  void cancelScan() {}
 }

--- a/lib/services/mock_api_service.dart
+++ b/lib/services/mock_api_service.dart
@@ -1054,6 +1054,7 @@ class MockApiService implements IApiService {
     bool useHttps, {
     required String config,
     required String section,
+    String? option,
     BuildContext? context,
   }) async {
     await Future.delayed(const Duration(milliseconds: 200));
@@ -1077,7 +1078,7 @@ class MockApiService implements IApiService {
       object: 'uci',
       method: 'get',
       params: {'config': config},
-      context: context,
+      context: context?.mounted == true ? context : null,
     );
   }
 

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1516,6 +1516,29 @@ class AppState extends ChangeNotifier {
     );
   }
 
+  /// Unwraps a LuCI `uci.get` RPC response into a flat section map.
+  ///
+  /// Real API shape: `[0, {"values": {"section": {...}, ...}}]`
+  /// Mock shape:     `[0, {"<configName>": {"section": {...}, ...}}]`
+  /// Some implementations return sections directly under `result[1]`.
+  ///
+  /// Returns `null` when the response cannot be parsed.
+  Map<String, dynamic>? _resolveUciSections(dynamic result, String configName) {
+    if (result is! List || result.length < 2) return null;
+    final outer = result[1];
+    if (outer is! Map) return null;
+    // Real API: sections under 'values'
+    if (outer['values'] is Map) {
+      return Map<String, dynamic>.from(outer['values'] as Map);
+    }
+    // Mock: sections under the config name key (e.g. 'wireless', 'firewall')
+    if (outer[configName] is Map) {
+      return Map<String, dynamic>.from(outer[configName] as Map);
+    }
+    // Flat map — sections directly at result[1]
+    return Map<String, dynamic>.from(outer);
+  }
+
   /// Restarts a specific radio via UCI disable/enable cycle.
   /// This is more reliable than `wifi reload` which doesn't work on all routers.
   /// Throws if the re-enable step fails (leaving the radio disabled is worse
@@ -1860,18 +1883,7 @@ class AppState extends ChangeNotifier {
           config: 'wireless',
           context: context,
         );
-        // Unwrap LuCI's [status, {values: {...}}] response shape.
-        // Real API returns result[1]['values'], mock returns result[1]['wireless'].
-        Map<String, dynamic>? _resolveUciSections(dynamic uciResult) {
-          if (uciResult is! List || uciResult.length < 2) return null;
-          final outer = uciResult[1];
-          if (outer is! Map) return null;
-          if (outer['values'] is Map) return Map<String, dynamic>.from(outer['values'] as Map);
-          if (outer['wireless'] is Map) return Map<String, dynamic>.from(outer['wireless'] as Map);
-          // Flat map (some implementations return sections directly)
-          return Map<String, dynamic>.from(outer);
-        }
-        final wirelessSections = _resolveUciSections(uciResult);
+        final wirelessSections = _resolveUciSections(uciResult, 'wireless');
         if (wirelessSections != null) {
           final wirelessConfig = wirelessSections;
           final sections = wirelessConfig.keys.toSet();
@@ -1961,7 +1973,10 @@ class AppState extends ChangeNotifier {
 
         Logger.info('UCI add result: $addResult');
 
-        // 2. Create network interface (always — wwan may not exist on a fresh router)
+        // 2. Create network interface (always — wwan may not exist on a fresh router).
+        // Only suppress errors that indicate the section already exists; all other
+        // failures mean the network interface was not created and we must stop here
+        // (the station would be committed but reference a non-existent network).
         try {
           await _apiService!.uciAdd(
             ip, auth, https,
@@ -1973,7 +1988,19 @@ class AppState extends ChangeNotifier {
           );
           Logger.info('Created network interface: $staNetworkName');
         } catch (e) {
-          Logger.warning('Network interface may already exist: $e');
+          final msg = e.toString().toLowerCase();
+          final isDuplicate = msg.contains('already exist') ||
+              msg.contains('duplicate') ||
+              msg.contains('entry exists') ||
+              msg.contains('-6'); // EEXIST from ubus
+          if (!isDuplicate) {
+            Logger.exception(
+              'Failed to create network interface $staNetworkName; aborting connect', e, StackTrace.current);
+            _dashboardError = 'Failed to create network interface: $e';
+            notifyListeners();
+            return false;
+          }
+          Logger.warning('Network interface $staNetworkName already exists, continuing');
         }
         
         // 3. Add to firewall WAN zone if not already there
@@ -1985,16 +2012,7 @@ class AppState extends ChangeNotifier {
           );
           bool foundInWan = false;
           int wanZoneIndex = -1;
-          // Resolve sections (same unwrap logic as wireless config above)
-          Map<String, dynamic>? firewallSections;
-          if (firewallResult is List && firewallResult.length > 1 && firewallResult[1] is Map) {
-            final outer = firewallResult[1] as Map<String, dynamic>;
-            if (outer['values'] is Map) {
-              firewallSections = Map<String, dynamic>.from(outer['values'] as Map);
-            } else {
-              firewallSections = Map<String, dynamic>.from(outer);
-            }
-          }
+          final firewallSections = _resolveUciSections(firewallResult, 'firewall');
           if (firewallSections != null) {
             final firewallConfig = firewallSections;
             int zoneIndex = 0;

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -119,6 +119,13 @@ class AppState extends ChangeNotifier {
     _initialize();
   }
 
+  @visibleForTesting
+  AppState.forTesting({
+    required IApiService apiService,
+    required IAuthService authService,
+  }) : _apiService = apiService,
+       _authService = authService;
+
   static AppState get instance {
     return _instance ??= AppState._();
   }
@@ -1551,7 +1558,7 @@ class AppState extends ChangeNotifier {
     final ip = _authService!.ipAddress!;
     final auth = _authService!.sysauth!;
     final https = _authService!.useHttps;
-    // Persist and apply the disabled state before re-enabling the radio.
+    var disableStaged = false;
     try {
       await _apiService!.uciSet(
         ip,
@@ -1562,6 +1569,7 @@ class AppState extends ChangeNotifier {
         values: {'disabled': '1'},
         context: context,
       );
+      disableStaged = true;
       await _apiService!.uciCommit(
         ip,
         auth,
@@ -1577,46 +1585,83 @@ class AppState extends ChangeNotifier {
         params: ['down', radioName],
         context: context?.mounted == true ? context : null,
       );
-    } catch (e) {
-      Logger.warning(
-        'Radio disable failed for $radioName: $e — aborting restart',
+      await Future.delayed(Duration(seconds: delaySeconds));
+
+      await _apiService!.uciSet(
+        ip,
+        auth,
+        https,
+        config: 'wireless',
+        section: radioName,
+        values: {'disabled': '0'},
+        context: context?.mounted == true ? context : null,
       );
-      rethrow;
+      await _apiService!.uciCommit(
+        ip,
+        auth,
+        https,
+        config: 'wireless',
+        context: context?.mounted == true ? context : null,
+      );
+      await _apiService!.systemExec(
+        ip,
+        auth,
+        https,
+        command: '/sbin/wifi',
+        params: ['up', radioName],
+        context: context?.mounted == true ? context : null,
+      );
+      disableStaged = false;
+
+      await Future.delayed(Duration(seconds: delaySeconds));
+      try {
+        await fetchDashboardData();
+      } catch (_) {}
+    } catch (error, stack) {
+      Object? restoreError;
+      if (disableStaged) {
+        try {
+          await _apiService!.uciSet(
+            ip,
+            auth,
+            https,
+            config: 'wireless',
+            section: radioName,
+            values: {'disabled': '0'},
+            context: context?.mounted == true ? context : null,
+          );
+          await _apiService!.uciCommit(
+            ip,
+            auth,
+            https,
+            config: 'wireless',
+            context: context?.mounted == true ? context : null,
+          );
+          await _apiService!.systemExec(
+            ip,
+            auth,
+            https,
+            command: '/sbin/wifi',
+            params: ['up', radioName],
+            context: context?.mounted == true ? context : null,
+          );
+        } catch (e, restoreStack) {
+          restoreError = e;
+          Logger.exception(
+            'Failed to restore radio $radioName after restart failure',
+            e,
+            restoreStack,
+          );
+        }
+      }
+      if (restoreError != null) {
+        Error.throwWithStackTrace(
+          Exception('$error; radio restore also failed: $restoreError'),
+          stack,
+        );
+      }
+      Error.throwWithStackTrace(error, stack);
     }
-
-    await Future.delayed(Duration(seconds: delaySeconds));
-
-    // Re-enable — must not suppress: a failure here leaves the radio disabled.
-    await _apiService!.uciSet(
-      ip,
-      auth,
-      https,
-      config: 'wireless',
-      section: radioName,
-      values: {'disabled': '0'},
-      context: context?.mounted == true ? context : null,
-    );
-    await _apiService!.systemExec(
-      ip,
-      auth,
-      https,
-      command: '/sbin/wifi',
-      params: ['up', radioName],
-      context: context?.mounted == true ? context : null,
-    );
-    await _apiService!.uciCommit(
-      ip,
-      auth,
-      https,
-      config: 'wireless',
-      context: context?.mounted == true ? context : null,
-    );
-
-    await Future.delayed(Duration(seconds: delaySeconds));
-
-    try {
-      await fetchDashboardData();
-    } catch (_) {}
   }
 
   /// Helper: restarts all known radios via UCI disable/enable cycle.
@@ -1939,55 +1984,63 @@ class AppState extends ChangeNotifier {
       }
       final sectionName = existingStaSection ?? 'wifinet${maxWifinetIndex + 1}';
 
-      // Persist the dependency first. A wireless station is never staged or
-      // restarted unless its DHCP interface has committed successfully.
-      final networkResult = await _apiService!.uciGetAll(
-        ip,
-        auth,
-        https,
-        config: 'network',
-        context: context?.mounted == true ? context : null,
-      );
-      final networkSections = _resolveUciSections(networkResult, 'network');
-      if (networkSections == null) {
-        throw const FormatException('Invalid network configuration response');
-      }
-      if (!networkSections.containsKey(staNetworkName)) {
-        await _apiService!.uciAdd(
+      var createdNetwork = false;
+      var addedToWan = false;
+      var wanZoneIndex = -1;
+      var createdStation = false;
+      var updatedStation = false;
+      var restartAttempted = false;
+      try {
+        // Persist the dependency first. A wireless station is never staged or
+        // restarted unless its DHCP interface has committed successfully.
+        final networkResult = await _apiService!.uciGetAll(
           ip,
           auth,
           https,
           config: 'network',
-          type: 'interface',
-          name: staNetworkName,
-          values: {'proto': 'dhcp'},
           context: context?.mounted == true ? context : null,
         );
-      }
-      await _apiService!.uciCommit(
-        ip,
-        auth,
-        https,
-        config: 'network',
-        context: context?.mounted == true ? context : null,
-      );
-
-      // WAN membership is optional for firewall-less routers, but when a WAN
-      // zone exists, add and commit the station network before wireless.
-      try {
-        final firewallResult = await _apiService!.uciGetAll(
+        final networkSections = _resolveUciSections(networkResult, 'network');
+        if (networkSections == null) {
+          throw const FormatException('Invalid network configuration response');
+        }
+        if (!networkSections.containsKey(staNetworkName)) {
+          await _apiService!.uciAdd(
+            ip,
+            auth,
+            https,
+            config: 'network',
+            type: 'interface',
+            name: staNetworkName,
+            values: {'proto': 'dhcp'},
+            context: context?.mounted == true ? context : null,
+          );
+          createdNetwork = true;
+        }
+        await _apiService!.uciCommit(
           ip,
           auth,
           https,
-          config: 'firewall',
+          config: 'network',
           context: context?.mounted == true ? context : null,
         );
-        final firewallSections = _resolveUciSections(
-          firewallResult,
-          'firewall',
-        );
+
+        // WAN membership is optional for firewall-less routers, but when a WAN
+        // zone exists, add and commit the station network before wireless.
+        Map<String, dynamic>? firewallSections;
+        try {
+          final firewallResult = await _apiService!.uciGetAll(
+            ip,
+            auth,
+            https,
+            config: 'firewall',
+            context: context?.mounted == true ? context : null,
+          );
+          firewallSections = _resolveUciSections(firewallResult, 'firewall');
+        } catch (e) {
+          Logger.warning('Could not read firewall configuration: $e');
+        }
         var zoneIndex = 0;
-        var wanZoneIndex = -1;
         var foundInWan = false;
         if (firewallSections != null) {
           for (final entry in firewallSections.entries) {
@@ -2024,6 +2077,7 @@ class AppState extends ChangeNotifier {
             ],
             context: context?.mounted == true ? context : null,
           );
+          addedToWan = true;
           await _apiService!.uciCommit(
             ip,
             auth,
@@ -2032,81 +2086,259 @@ class AppState extends ChangeNotifier {
             context: context?.mounted == true ? context : null,
           );
         }
-      } catch (e) {
-        Logger.warning('Failed to add $staNetworkName to the WAN zone: $e');
-      }
 
-      if (existingStaSection != null) {
-        await _apiService!.uciSet(
-          ip,
-          auth,
-          https,
-          config: 'wireless',
-          section: sectionName,
-          values: {
-            'network': staNetworkName,
-            'ssid': ssid,
-            'encryption': encryption,
-            if (password.isNotEmpty) 'key': password,
-            if (bssid?.isNotEmpty == true) 'bssid': bssid!,
-          },
-          context: context?.mounted == true ? context : null,
-        );
-        if (password.isEmpty && existingStaConfig?.containsKey('key') == true) {
-          await _apiService!.uciDelete(
+        if (existingStaSection != null) {
+          await _apiService!.uciSet(
             ip,
             auth,
             https,
             config: 'wireless',
             section: sectionName,
-            option: 'key',
+            values: {
+              'network': staNetworkName,
+              'ssid': ssid,
+              'encryption': encryption,
+              if (password.isNotEmpty) 'key': password,
+              if (bssid?.isNotEmpty == true) 'bssid': bssid!,
+            },
             context: context?.mounted == true ? context : null,
           );
-        }
-        if (bssid?.isNotEmpty != true &&
-            existingStaConfig?.containsKey('bssid') == true) {
-          await _apiService!.uciDelete(
+          updatedStation = true;
+          if (password.isEmpty &&
+              existingStaConfig?.containsKey('key') == true) {
+            await _apiService!.uciDelete(
+              ip,
+              auth,
+              https,
+              config: 'wireless',
+              section: sectionName,
+              option: 'key',
+              context: context?.mounted == true ? context : null,
+            );
+          }
+          if (bssid?.isNotEmpty != true &&
+              existingStaConfig?.containsKey('bssid') == true) {
+            await _apiService!.uciDelete(
+              ip,
+              auth,
+              https,
+              config: 'wireless',
+              section: sectionName,
+              option: 'bssid',
+              context: context?.mounted == true ? context : null,
+            );
+          }
+        } else {
+          await _apiService!.uciAdd(
             ip,
             auth,
             https,
             config: 'wireless',
-            section: sectionName,
-            option: 'bssid',
+            type: 'wifi-iface',
+            name: sectionName,
+            values: {
+              'device': radioDevice,
+              'network': staNetworkName,
+              'mode': 'sta',
+              'ssid': ssid,
+              'encryption': encryption,
+              if (password.isNotEmpty) 'key': password,
+              if (bssid?.isNotEmpty == true) 'bssid': bssid!,
+            },
             context: context?.mounted == true ? context : null,
           );
+          createdStation = true;
         }
-      } else {
-        await _apiService!.uciAdd(
+        await _apiService!.uciCommit(
           ip,
           auth,
           https,
           config: 'wireless',
-          type: 'wifi-iface',
-          name: sectionName,
-          values: {
-            'device': radioDevice,
-            'network': staNetworkName,
-            'mode': 'sta',
-            'ssid': ssid,
-            'encryption': encryption,
-            if (password.isNotEmpty) 'key': password,
-            if (bssid?.isNotEmpty == true) 'bssid': bssid!,
-          },
           context: context?.mounted == true ? context : null,
         );
-      }
-      await _apiService!.uciCommit(
-        ip,
-        auth,
-        https,
-        config: 'wireless',
-        context: context?.mounted == true ? context : null,
-      );
 
-      await _restartRadioViaUci(
-        radioDevice,
-        context: context?.mounted == true ? context : null,
-      );
+        restartAttempted = true;
+        await _restartRadioViaUci(
+          radioDevice,
+          context: context?.mounted == true ? context : null,
+        );
+      } catch (error, stack) {
+        final rollbackErrors = <String>[];
+        var wirelessRolledBack = false;
+
+        Future<void> attemptRollback(
+          String label,
+          Future<void> Function() action,
+        ) async {
+          try {
+            await action();
+          } catch (e, rollbackStack) {
+            rollbackErrors.add('$label: $e');
+            Logger.exception('Failed to roll back $label', e, rollbackStack);
+          }
+        }
+
+        if (createdStation) {
+          await attemptRollback('wireless section $sectionName', () async {
+            await _apiService!.uciDelete(
+              ip,
+              auth,
+              https,
+              config: 'wireless',
+              section: sectionName,
+              context: context?.mounted == true ? context : null,
+            );
+            await _apiService!.uciCommit(
+              ip,
+              auth,
+              https,
+              config: 'wireless',
+              context: context?.mounted == true ? context : null,
+            );
+            wirelessRolledBack = true;
+          });
+        } else if (updatedStation && existingStaConfig != null) {
+          await attemptRollback('wireless section $sectionName', () async {
+            const touchedOptions = {
+              'network',
+              'ssid',
+              'encryption',
+              'key',
+              'bssid',
+            };
+            final setOptions = {
+              'network',
+              'ssid',
+              'encryption',
+              if (password.isNotEmpty) 'key',
+              if (bssid?.isNotEmpty == true) 'bssid',
+            };
+            final originalValues = <String, String>{};
+            for (final option in touchedOptions) {
+              final value = existingStaConfig![option];
+              if (value != null) {
+                originalValues[option] = value is List
+                    ? value.join(' ')
+                    : value.toString();
+              }
+            }
+            if (originalValues.isNotEmpty) {
+              await _apiService!.uciSet(
+                ip,
+                auth,
+                https,
+                config: 'wireless',
+                section: sectionName,
+                values: originalValues,
+                context: context?.mounted == true ? context : null,
+              );
+            }
+            for (final option in setOptions) {
+              if (!existingStaConfig!.containsKey(option)) {
+                await _apiService!.uciDelete(
+                  ip,
+                  auth,
+                  https,
+                  config: 'wireless',
+                  section: sectionName,
+                  option: option,
+                  context: context?.mounted == true ? context : null,
+                );
+              }
+            }
+            await _apiService!.uciCommit(
+              ip,
+              auth,
+              https,
+              config: 'wireless',
+              context: context?.mounted == true ? context : null,
+            );
+            wirelessRolledBack = true;
+          });
+        }
+
+        if (addedToWan) {
+          await attemptRollback('WAN firewall membership', () async {
+            await _apiService!.systemExec(
+              ip,
+              auth,
+              https,
+              command: '/sbin/uci',
+              params: [
+                'del_list',
+                'firewall.@zone[$wanZoneIndex].network=$staNetworkName',
+              ],
+              context: context?.mounted == true ? context : null,
+            );
+            await _apiService!.uciCommit(
+              ip,
+              auth,
+              https,
+              config: 'firewall',
+              context: context?.mounted == true ? context : null,
+            );
+          });
+        }
+
+        if (createdNetwork) {
+          await attemptRollback('network interface $staNetworkName', () async {
+            await _apiService!.uciDelete(
+              ip,
+              auth,
+              https,
+              config: 'network',
+              section: staNetworkName,
+              context: context?.mounted == true ? context : null,
+            );
+            await _apiService!.uciCommit(
+              ip,
+              auth,
+              https,
+              config: 'network',
+              context: context?.mounted == true ? context : null,
+            );
+          });
+        }
+
+        if (restartAttempted && wirelessRolledBack) {
+          await attemptRollback('wireless runtime state', () async {
+            await _apiService!.uciSet(
+              ip,
+              auth,
+              https,
+              config: 'wireless',
+              section: radioDevice,
+              values: {'disabled': '0'},
+              context: context?.mounted == true ? context : null,
+            );
+            await _apiService!.uciCommit(
+              ip,
+              auth,
+              https,
+              config: 'wireless',
+              context: context?.mounted == true ? context : null,
+            );
+            await _apiService!.systemExec(
+              ip,
+              auth,
+              https,
+              command: '/sbin/wifi',
+              params: ['up', radioDevice],
+              context: context?.mounted == true ? context : null,
+            );
+          });
+        }
+
+        if (rollbackErrors.isNotEmpty) {
+          Error.throwWithStackTrace(
+            Exception(
+              '$error; rollback incomplete: ${rollbackErrors.join('; ')}',
+            ),
+            stack,
+          );
+        }
+        Error.throwWithStackTrace(error, stack);
+      }
 
       return true;
     } catch (e, stack) {

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -2511,16 +2511,22 @@ class AppState extends ChangeNotifier {
         config: 'wireless',
         context: context?.mounted == true ? context : null,
       );
-
-      await _wifiReload(context: context?.mounted == true ? context : null);
-
-      return true;
     } catch (e, stack) {
-      Logger.exception('Failed to modify wireless interface', e, stack);
+      Logger.exception('Failed to modify wireless interface (UCI)', e, stack);
       _dashboardError = 'Failed to modify interface: $e';
       notifyListeners();
       return false;
     }
+
+    try {
+      await _wifiReload(context: context?.mounted == true ? context : null);
+    } catch (e, stack) {
+      Logger.exception('Wireless reload failed after interface edit', e, stack);
+      _dashboardError = 'Interface modified but wireless reload failed: $e';
+      notifyListeners();
+      return false;
+    }
+    return true;
   }
 
   /// Deletes a wifi-iface UCI section.
@@ -2557,16 +2563,26 @@ class AppState extends ChangeNotifier {
         config: 'wireless',
         context: context?.mounted == true ? context : null,
       );
-
-      await _wifiReload(context: context?.mounted == true ? context : null);
-
-      return true;
     } catch (e, stack) {
-      Logger.exception('Failed to delete wireless interface', e, stack);
+      Logger.exception('Failed to delete wireless interface (UCI)', e, stack);
       _dashboardError = 'Failed to delete interface: $e';
       notifyListeners();
       return false;
     }
+
+    try {
+      await _wifiReload(context: context?.mounted == true ? context : null);
+    } catch (e, stack) {
+      Logger.exception(
+        'Wireless reload failed after interface deletion',
+        e,
+        stack,
+      );
+      _dashboardError = 'Interface deleted but wireless reload failed: $e';
+      notifyListeners();
+      return false;
+    }
+    return true;
   }
 
   Future<bool> tryAutoLogin({BuildContext? context}) async {

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -2257,47 +2257,59 @@ class AppState extends ChangeNotifier {
           });
         }
 
-        if (addedToWan) {
-          await attemptRollback('WAN firewall membership', () async {
-            await _apiService!.systemExec(
-              ip,
-              auth,
-              https,
-              command: '/sbin/uci',
-              params: [
-                'del_list',
-                'firewall.@zone[$wanZoneIndex].network=$staNetworkName',
-              ],
-              context: context?.mounted == true ? context : null,
-            );
-            await _apiService!.uciCommit(
-              ip,
-              auth,
-              https,
-              config: 'firewall',
-              context: context?.mounted == true ? context : null,
-            );
-          });
-        }
+        final canRemoveDependencies =
+            (!createdStation && !updatedStation) || wirelessRolledBack;
+        if (canRemoveDependencies) {
+          if (addedToWan) {
+            await attemptRollback('WAN firewall membership', () async {
+              await _apiService!.systemExec(
+                ip,
+                auth,
+                https,
+                command: '/sbin/uci',
+                params: [
+                  'del_list',
+                  'firewall.@zone[$wanZoneIndex].network=$staNetworkName',
+                ],
+                context: context?.mounted == true ? context : null,
+              );
+              await _apiService!.uciCommit(
+                ip,
+                auth,
+                https,
+                config: 'firewall',
+                context: context?.mounted == true ? context : null,
+              );
+            });
+          }
 
-        if (createdNetwork) {
-          await attemptRollback('network interface $staNetworkName', () async {
-            await _apiService!.uciDelete(
-              ip,
-              auth,
-              https,
-              config: 'network',
-              section: staNetworkName,
-              context: context?.mounted == true ? context : null,
+          if (createdNetwork) {
+            await attemptRollback(
+              'network interface $staNetworkName',
+              () async {
+                await _apiService!.uciDelete(
+                  ip,
+                  auth,
+                  https,
+                  config: 'network',
+                  section: staNetworkName,
+                  context: context?.mounted == true ? context : null,
+                );
+                await _apiService!.uciCommit(
+                  ip,
+                  auth,
+                  https,
+                  config: 'network',
+                  context: context?.mounted == true ? context : null,
+                );
+              },
             );
-            await _apiService!.uciCommit(
-              ip,
-              auth,
-              https,
-              config: 'network',
-              context: context?.mounted == true ? context : null,
-            );
-          });
+          }
+        } else {
+          rollbackErrors.add(
+            'kept $staNetworkName dependencies because wireless section '
+            '$sectionName could not be restored',
+          );
         }
 
         if (restartAttempted && wirelessRolledBack) {

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -2068,8 +2068,8 @@ class AppState extends ChangeNotifier {
           context: context?.mounted == true ? context : null,
         );
 
-        // WAN membership is optional for firewall-less routers, but when a WAN
-        // zone exists, add and commit the station network before wireless.
+        // WAN membership is optional when the firewall config is absent, but a
+        // failed read must abort before wireless is staged.
         Map<String, dynamic>? firewallSections;
         try {
           final firewallResult = await _apiService!.uciGetAll(
@@ -2080,33 +2080,37 @@ class AppState extends ChangeNotifier {
             context: context?.mounted == true ? context : null,
           );
           firewallSections = _resolveUciSections(firewallResult, 'firewall');
-        } catch (e) {
-          Logger.warning('Could not read firewall configuration: $e');
+        } on RpcException catch (e) {
+          if (e.status != 4) rethrow;
+          firewallSections = {};
+        }
+        if (firewallSections == null) {
+          throw const FormatException(
+            'Invalid firewall configuration response',
+          );
         }
         var zoneIndex = 0;
         var foundInWan = false;
-        if (firewallSections != null) {
-          for (final entry in firewallSections.entries) {
-            final section = entry.value;
-            if (section is! Map || section['.type']?.toString() != 'zone') {
-              continue;
-            }
-            if (section['name']?.toString() == 'wan') {
-              wanZoneIndex = zoneIndex;
-              final networks = section['network'];
-              foundInWan = networks is List
-                  ? networks
-                        .map((value) => value.toString())
-                        .contains(staNetworkName)
-                  : networks
-                            ?.toString()
-                            .split(RegExp(r'\s+'))
-                            .contains(staNetworkName) ==
-                        true;
-              break;
-            }
-            zoneIndex++;
+        for (final entry in firewallSections.entries) {
+          final section = entry.value;
+          if (section is! Map || section['.type']?.toString() != 'zone') {
+            continue;
           }
+          if (section['name']?.toString() == 'wan') {
+            wanZoneIndex = zoneIndex;
+            final networks = section['network'];
+            foundInWan = networks is List
+                ? networks
+                      .map((value) => value.toString())
+                      .contains(staNetworkName)
+                : networks
+                          ?.toString()
+                          .split(RegExp(r'\s+'))
+                          .contains(staNetworkName) ==
+                      true;
+            break;
+          }
+          zoneIndex++;
         }
         if (!foundInWan && wanZoneIndex >= 0) {
           await _apiService!.systemExec(

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -18,6 +18,7 @@ import 'package:luci_mobile/services/service_factory.dart';
 import 'package:luci_mobile/config/app_config.dart';
 import 'package:luci_mobile/utils/http_client_manager.dart';
 import 'package:luci_mobile/utils/logger.dart';
+import 'package:luci_mobile/models/wifi_scan_result.dart';
 
 class AppState extends ChangeNotifier {
   static AppState? _instance;
@@ -1515,6 +1516,86 @@ class AppState extends ChangeNotifier {
     );
   }
 
+  /// Restarts a specific radio via UCI disable/enable cycle.
+  /// This is more reliable than `wifi reload` which doesn't work on all routers.
+  /// Never throws — failures are logged but don't fail the calling operation.
+  Future<void> _restartRadioViaUci(
+    String radioName, {
+    BuildContext? context,
+    int delaySeconds = 5,
+  }) async {
+    final ip = _authService!.ipAddress!;
+    final auth = _authService!.sysauth!;
+    final https = _authService!.useHttps;
+    final safeCtx = context?.mounted == true ? context : null;
+
+    try {
+      // Disable the radio
+      await _apiService!.uciSet(
+        ip, auth, https,
+        config: 'wireless',
+        section: radioName,
+        values: {'disabled': '1'},
+        context: safeCtx,
+      );
+      await _apiService!.uciCommit(
+        ip, auth, https,
+        config: 'wireless',
+        context: safeCtx,
+      );
+
+      await Future.delayed(Duration(seconds: delaySeconds));
+
+      // Re-enable the radio
+      await _apiService!.uciSet(
+        ip, auth, https,
+        config: 'wireless',
+        section: radioName,
+        values: {'disabled': '0'},
+        context: safeCtx,
+      );
+      await _apiService!.uciCommit(
+        ip, auth, https,
+        config: 'wireless',
+        context: safeCtx,
+      );
+
+      await Future.delayed(Duration(seconds: delaySeconds));
+    } catch (e) {
+      Logger.warning('Radio restart via UCI failed for $radioName: $e');
+    }
+
+    try {
+      await fetchDashboardData();
+    } catch (_) {}
+  }
+
+  /// Helper: restarts all known radios via UCI disable/enable cycle.
+  /// Used after operations that need wifi to reload (toggle, modify, delete).
+  /// Never throws.
+  Future<void> _wifiReload({
+    BuildContext? context,
+  }) async {
+    // Get list of radios from dashboard data
+    final wirelessData =
+        _dashboardData?['wireless'] as Map<String, dynamic>? ?? {};
+    final radios = wirelessData.keys.toList();
+
+    if (radios.isEmpty) {
+      Logger.warning('_wifiReload: no radios found in dashboard data');
+      await Future.delayed(const Duration(seconds: 4));
+      try {
+        await fetchDashboardData();
+      } catch (_) {}
+      return;
+    }
+
+    // Cycle all radios
+    for (final radio in radios) {
+      await _restartRadioViaUci(radio, context: context, delaySeconds: 3);
+    }
+  }
+
   Future<bool> setWirelessRadioState(
     String device,
     bool enabled, {
@@ -1568,6 +1649,583 @@ class AppState extends ChangeNotifier {
       return true;
     } catch (e) {
       _dashboardError = 'Failed to toggle Wi-Fi: $e';
+      notifyListeners();
+      return false;
+    }
+  }
+
+  /// Cancel any ongoing wireless network scan.
+  void cancelWirelessScan() {
+    _apiService?.cancelScan();
+  }
+
+  /// Scans for nearby wireless networks on a given radio interface.
+  /// [device] is the wireless device name (e.g., 'wlan0', 'phy0-ap0').
+  Future<List<WifiScanResult>> scanWirelessNetworks({
+    required String device,
+    BuildContext? context,
+  }) async {
+    if (_reviewerModeEnabled) {
+      // Use mock scan results in reviewer mode
+      final mockResults = await _apiService!.scanWirelessNetworks(
+        ipAddress: 'mock',
+        sysauth: 'mock',
+        useHttps: false,
+        device: device,
+        context: context,
+      );
+      return mockResults.map((r) => WifiScanResult.fromJson(r)).toList()
+        ..sort((a, b) => b.signal.compareTo(a.signal));
+    }
+
+    if (_authService?.sysauth == null || _authService?.ipAddress == null) {
+      throw Exception('Not authenticated');
+    }
+
+    try {
+      final results = await _apiService!.scanWirelessNetworks(
+        ipAddress: _authService!.ipAddress!,
+        sysauth: _authService!.sysauth!,
+        useHttps: _authService!.useHttps,
+        device: device,
+        context: context,
+      );
+
+      if (results.isEmpty) {
+        // Try with phy name (strip -ap0, -sta0 suffix) as fallback
+        final phyMatch = RegExp(r'^(phy\d+)-').firstMatch(device);
+        if (phyMatch != null) {
+          final phyName = phyMatch.group(1)!;
+          Logger.info('Scan returned empty on $device, retrying with $phyName');
+          final retryResults = await _apiService!.scanWirelessNetworks(
+            ipAddress: _authService!.ipAddress!,
+            sysauth: _authService!.sysauth!,
+            useHttps: _authService!.useHttps,
+            device: phyName,
+            context: context,
+          );
+          if (retryResults.isNotEmpty) {
+            return retryResults.map((r) => WifiScanResult.fromJson(r)).toList()
+              ..sort((a, b) => b.signal.compareTo(a.signal));
+          }
+        }
+      }
+
+      final scanResults =
+          results.map((r) => WifiScanResult.fromJson(r)).toList()
+            ..sort((a, b) => b.signal.compareTo(a.signal));
+      return scanResults;
+    } catch (e, stack) {
+      Logger.exception('Failed to scan wireless networks', e, stack);
+      rethrow; // Let the UI show the actual error
+    }
+  }
+
+  /// Returns a list of available wireless radio devices (e.g., wlan0, wlan1)
+  /// from the current dashboard data.
+  List<Map<String, String>> getAvailableRadioDevices() {
+    final wirelessData =
+        _dashboardData?['wireless'] as Map<String, dynamic>? ?? {};
+    final devices = <Map<String, String>>[];
+
+    wirelessData.forEach((radioName, radioData) {
+      if (radioData is Map<String, dynamic>) {
+        final interfaces = radioData['interfaces'] as List<dynamic>?;
+
+        // Determine band from frequency/channel
+        final freq = radioData['frequency'];
+        final channel = radioData['channel'];
+        String band = '';
+        if (freq is int) {
+          band = freq >= 5000 ? '5 GHz' : freq >= 4000 ? '4 GHz' : '2.4 GHz';
+        } else if (channel is int) {
+          band = channel >= 36 ? '5 GHz' : '2.4 GHz';
+        }
+
+        if (interfaces != null && interfaces.isNotEmpty) {
+          // Find the best interface for scanning:
+          // Prefer an AP interface, fall back to any active interface
+          String? bestIfname;
+          String bestSsid = radioName;
+          for (final iface in interfaces) {
+            final ifname = iface['ifname'] as String?;
+            if (ifname == null) continue;
+            final config = iface['config'] as Map<String, dynamic>? ?? {};
+            final iwinfo = iface['iwinfo'] as Map<String, dynamic>? ?? {};
+            final mode = config['mode']?.toString() ?? '';
+            final ssid =
+                (iwinfo['ssid'] ?? config['ssid'] ?? '').toString();
+
+            if (bestIfname == null || mode == 'ap') {
+              bestIfname = ifname;
+              if (ssid.isNotEmpty) bestSsid = ssid;
+            }
+            // If we found an AP interface, stop looking
+            if (mode == 'ap') break;
+          }
+
+          devices.add({
+            'ifname': bestIfname ?? radioName,
+            'radioName': radioName,
+            'ssid': bestSsid,
+            'band': band,
+          });
+        } else {
+          // Radio exists but has no interfaces - still usable for scanning
+          devices.add({
+            'ifname': radioName,
+            'radioName': radioName,
+            'ssid': radioName,
+            'band': band,
+          });
+        }
+      }
+    });
+    return devices;
+  }
+
+  /// Restarts a wireless radio via UCI disable/enable cycle.
+  Future<bool> restartWirelessRadio(
+    String radioName, {
+    BuildContext? context,
+  }) async {
+    if (_reviewerModeEnabled) {
+      await Future.delayed(const Duration(seconds: 2));
+      await fetchDashboardData();
+      return true;
+    }
+
+    if (_authService?.sysauth == null || _authService?.ipAddress == null) {
+      return false;
+    }
+
+    try {
+      Logger.info('Restarting radio $radioName via UCI cycle');
+      await _restartRadioViaUci(radioName, context: context);
+      return true;
+    } catch (e, stack) {
+      Logger.exception('Failed to restart radio $radioName', e, stack);
+      _dashboardError = 'Failed to restart radio: $e';
+      notifyListeners();
+      return false;
+    }
+  }
+
+  /// Connects to a wireless network by creating a new wifi-iface in station mode.
+  ///
+  /// [radioDevice] is the radio to use (e.g., 'radio0').
+  /// [ssid] is the network SSID to connect to.
+  /// [encryption] is the OpenWrt encryption type (e.g., 'psk2', 'sae', 'none').
+  /// [password] is the network password (empty for open networks).
+  /// [networkName] is the UCI network name to bind to (defaults to 'wwan').
+  Future<bool> connectToWirelessNetwork({
+    required String radioDevice,
+    required String ssid,
+    required String encryption,
+    String password = '',
+    String? bssid,
+    BuildContext? context,
+  }) async {
+    if (_reviewerModeEnabled) {
+      await Future.delayed(const Duration(seconds: 2));
+      await fetchDashboardData();
+      return true;
+    }
+
+    if (_authService?.sysauth == null || _authService?.ipAddress == null) {
+      return false;
+    }
+
+    try {
+      final ip = _authService!.ipAddress!;
+      final auth = _authService!.sysauth!;
+      final https = _authService!.useHttps;
+
+      // Use radio-specific network name to avoid conflicts between radios
+      // radio0 -> wwan, radio1 -> wwan1, radio2 -> wwan2, etc
+      final radioIndex = int.tryParse(radioDevice.replaceAll('radio', '')) ?? 0;
+      final staNetworkName = radioIndex == 0 ? 'wwan' : 'wwan$radioIndex';
+
+      // Find next available wifinet# name properly
+      String sectionName = 'wifinet0';
+      bool existingStaUpdated = false;
+      
+      try {
+        final uciResult = await _apiService!.uciGetAll(
+          ip, auth, https,
+          config: 'wireless',
+          context: context,
+        );
+        if (uciResult is List && uciResult.length > 1 && uciResult[1] is Map) {
+          final wirelessConfig = uciResult[1] as Map<String, dynamic>;
+          final sections = wirelessConfig.keys.toSet();
+
+          // Find existing STA on this radio - if exists, update it
+          String? existingStaOnThisRadio;
+          for (final sectionKey in sections) {
+            final section = wirelessConfig[sectionKey];
+            if (section is Map<String, dynamic>) {
+              final device = section['device']?.toString();
+              final mode = section['mode']?.toString();
+              if (device == radioDevice && mode == 'sta') {
+                existingStaOnThisRadio = sectionKey.toString();
+                break;
+              }
+            }
+          }
+
+          if (existingStaOnThisRadio != null) {
+            // Found existing STA on this radio - update it
+            Logger.info('Found existing STA on $radioDevice, updating section $existingStaOnThisRadio');
+            await _apiService!.uciSet(
+              ip, auth, https,
+              config: 'wireless',
+              section: existingStaOnThisRadio,
+              values: {
+                'network': staNetworkName,
+                'ssid': ssid,
+                'encryption': encryption,
+                if (password.isNotEmpty) 'key': password,
+                if (bssid != null && bssid.isNotEmpty) 'bssid': bssid,
+              },
+              context: context,
+            );
+            existingStaUpdated = true;
+            sectionName = existingStaOnThisRadio;
+          } else {
+            // No existing STA on this radio - create new with proper wifinet#
+            Logger.info('No existing STA on $radioDevice, creating new section');
+            int maxIdx = -1;
+            for (final key in sections) {
+              if (key.toString().startsWith('wifinet')) {
+                final numStr = key.toString().replaceAll('wifinet', '');
+                final num = int.tryParse(numStr);
+                if (num != null && num > maxIdx) {
+                  maxIdx = num;
+                }
+              }
+            }
+            sectionName = 'wifinet${maxIdx + 1}';
+            Logger.info('Selected new section name: $sectionName (max was $maxIdx)');
+          }
+        }
+      } catch (e) {
+        Logger.warning('Could not query existing sections: $e');
+      }
+
+      // If we didn't update an existing STA, create new one
+      if (!existingStaUpdated) {
+        Logger.info('Creating new wifi-iface section: $sectionName with network: $staNetworkName');
+
+        final values = <String, dynamic>{
+          'device': radioDevice,
+          'network': staNetworkName,
+          'mode': 'sta',
+          'ssid': ssid,
+          'encryption': encryption,
+        };
+        if (password.isNotEmpty) {
+          values['key'] = password;
+        }
+        if (bssid != null && bssid.isNotEmpty) {
+          values['bssid'] = bssid;
+        }
+
+        // 1. Add a named wifi-iface section
+        final addResult = await _apiService!.uciAdd(
+          ip,
+          auth,
+          https,
+          config: 'wireless',
+          type: 'wifi-iface',
+          name: sectionName,
+          values: values,
+          context: context,
+        );
+
+        Logger.info('UCI add result: $addResult');
+
+        // 2. Create network interface if needed (for wwan1, wwan2, etc.)
+        if (staNetworkName != 'wwan') {
+          try {
+            await _apiService!.uciAdd(
+              ip, auth, https,
+              config: 'network',
+              type: 'interface',
+              name: staNetworkName,
+              values: {'proto': 'dhcp'},
+              context: context,
+            );
+            Logger.info('Created network interface: $staNetworkName');
+          } catch (e) {
+            Logger.warning('Network interface may already exist: $e');
+          }
+        }
+        
+        // 3. Add to firewall WAN zone if not already there
+        try {
+          final firewallResult = await _apiService!.uciGetAll(
+            ip, auth, https,
+            config: 'firewall',
+            context: context,
+          );
+          bool foundInWan = false;
+          int wanZoneIndex = -1;
+          if (firewallResult is List && firewallResult.length > 1 && firewallResult[1] is Map) {
+            final firewallConfig = firewallResult[1] as Map<String, dynamic>;
+            int zoneIndex = 0;
+            for (final key in firewallConfig.keys) {
+              final section = firewallConfig[key];
+              if (section is Map<String, dynamic>) {
+                final typeName = section['.type']?.toString() ?? key.toString().split('@').first;
+                // Check if this is a zone section
+                if (typeName == 'zone' || (section.containsKey('name') && section.containsKey('input'))) {
+                  final zoneName = section['name']?.toString();
+                  if (zoneName == 'wan') {
+                    wanZoneIndex = zoneIndex;
+                    // Check if network is already in this zone
+                    final networks = section['network'];
+                    if (networks is String && networks == staNetworkName) {
+                      foundInWan = true;
+                      break;
+                    } else if (networks is String && networks.contains(staNetworkName)) {
+                      foundInWan = true;
+                      break;
+                    } else if (networks is List && networks.contains(staNetworkName)) {
+                      foundInWan = true;
+                      break;
+                    }
+                  }
+                  zoneIndex++;
+                }
+              }
+            }
+          }
+
+          if (!foundInWan && wanZoneIndex >= 0) {
+            // Use system command to add network to wan zone
+            // The systemExec splits by whitespace, so we pass each part separately
+            await _apiService!.systemExec(
+              ip, auth, https,
+              command: "uci add_list firewall.@zone[$wanZoneIndex].network=$staNetworkName",
+              context: context,
+            );
+            // Commit firewall changes
+            await _apiService!.uciCommit(
+              ip, auth, https,
+              config: 'firewall',
+              context: context,
+            );
+            Logger.info('Added $staNetworkName to WAN firewall zone at index $wanZoneIndex');
+          }
+        } catch (e) {
+          Logger.warning('Failed to add to firewall zone: $e');
+        }
+      }
+
+      // 4. Commit wireless configuration
+      await _apiService!.uciCommit(
+        ip,
+        auth,
+        https,
+        config: 'wireless',
+        context: context?.mounted == true ? context : null,
+      );
+
+      // 5. Commit network and firewall configuration
+      try {
+        await _apiService!.uciCommit(
+          ip, auth, https,
+          config: 'network',
+          context: context?.mounted == true ? context : null,
+        );
+      } catch (e) {
+        Logger.warning('Network commit failed: $e');
+      }
+      try {
+        await _apiService!.uciCommit(
+          ip, auth, https,
+          config: 'firewall',
+          context: context?.mounted == true ? context : null,
+        );
+      } catch (e) {
+        Logger.warning('Firewall commit failed: $e');
+      }
+
+      // 6. Restart radio to apply changes
+      await _restartRadioViaUci(radioDevice, context: context);
+
+      return true;
+    } catch (e, stack) {
+      Logger.exception('Failed to connect to wireless network', e, stack);
+      _dashboardError = 'Failed to connect to $ssid: $e';
+      notifyListeners();
+      return false;
+    }
+  }
+
+  /// Enables or disables a specific wifi-iface UCI section.
+  ///
+  /// [uciSection] is the UCI section name (e.g., 'default_radio0', 'wifinet0').
+  /// [enabled] true to enable, false to disable.
+  Future<bool> setWirelessInterfaceEnabled(
+    String uciSection,
+    bool enabled, {
+    BuildContext? context,
+  }) async {
+    if (_reviewerModeEnabled) {
+      await Future.delayed(const Duration(milliseconds: 500));
+      await fetchDashboardData();
+      return true;
+    }
+
+    if (_authService?.sysauth == null || _authService?.ipAddress == null) {
+      return false;
+    }
+
+    try {
+      Logger.info('Toggle interface $uciSection → ${enabled ? 'enabled' : 'disabled'}');
+
+      await _apiService!.uciSet(
+        _authService!.ipAddress!,
+        _authService!.sysauth!,
+        _authService!.useHttps,
+        config: 'wireless',
+        section: uciSection,
+        values: {'disabled': enabled ? '0' : '1'},
+        context: context,
+      );
+      Logger.info('UCI set done');
+
+      await _apiService!.uciCommit(
+        _authService!.ipAddress!,
+        _authService!.sysauth!,
+        _authService!.useHttps,
+        config: 'wireless',
+        context: context?.mounted == true ? context : null,
+      );
+      Logger.info('UCI commit done');
+    } catch (e, stack) {
+      // UCI operations failed — actual error
+      Logger.exception('Failed to toggle wireless interface (UCI)', e, stack);
+      _dashboardError = 'Failed to toggle interface: $e';
+      notifyListeners();
+      return false;
+    }
+
+    // UCI changes are committed — wait and refresh (don't cycle radios for toggle)
+    await Future.delayed(const Duration(seconds: 4));
+    try {
+      await fetchDashboardData();
+    } catch (_) {}
+    Logger.info('Toggle interface $uciSection complete');
+    return true;
+  }
+
+  /// Modifies properties of an existing wifi-iface UCI section.
+  ///
+  /// [uciSection] is the UCI section name (e.g., 'default_radio0').
+  /// [values] is a map of UCI option key-value pairs to set.
+  Future<bool> modifyWirelessInterface(
+    String uciSection,
+    Map<String, String> values, {
+    BuildContext? context,
+  }) async {
+    if (_reviewerModeEnabled) {
+      await Future.delayed(const Duration(seconds: 1));
+      await fetchDashboardData();
+      return true;
+    }
+
+    if (_authService?.sysauth == null || _authService?.ipAddress == null) {
+      return false;
+    }
+
+    try {
+      await _apiService!.uciSet(
+        _authService!.ipAddress!,
+        _authService!.sysauth!,
+        _authService!.useHttps,
+        config: 'wireless',
+        section: uciSection,
+        values: values,
+        context: context,
+      );
+
+      await _apiService!.uciCommit(
+        _authService!.ipAddress!,
+        _authService!.sysauth!,
+        _authService!.useHttps,
+        config: 'wireless',
+        context: context?.mounted == true ? context : null,
+      );
+
+      await _wifiReload(context: context);
+
+      return true;
+    } catch (e, stack) {
+      Logger.exception('Failed to modify wireless interface', e, stack);
+      _dashboardError = 'Failed to modify interface: $e';
+      notifyListeners();
+      return false;
+    }
+  }
+
+  /// Deletes a wifi-iface UCI section.
+  ///
+  /// [uciSection] is the UCI section name to remove.
+  /// [mode] is the interface mode ('ap' or 'sta') - if 'ap', WiFi will reload.
+  Future<bool> deleteWirelessInterface(
+    String uciSection, {
+    String mode = 'ap',
+    BuildContext? context,
+  }) async {
+    if (_reviewerModeEnabled) {
+      await Future.delayed(const Duration(milliseconds: 500));
+      await fetchDashboardData();
+      return true;
+    }
+
+    if (_authService?.sysauth == null || _authService?.ipAddress == null) {
+      return false;
+    }
+
+    try {
+      await _apiService!.uciDelete(
+        _authService!.ipAddress!,
+        _authService!.sysauth!,
+        _authService!.useHttps,
+        config: 'wireless',
+        section: uciSection,
+        context: context,
+      );
+
+      await _apiService!.uciCommit(
+        _authService!.ipAddress!,
+        _authService!.sysauth!,
+        _authService!.useHttps,
+        config: 'wireless',
+        context: context?.mounted == true ? context : null,
+      );
+
+      // Only reload WiFi for AP mode - STA deletion doesn't require radio restart
+      if (mode.toLowerCase().contains('sta') || 
+          mode.toLowerCase().contains('client') ||
+          mode.toLowerCase() == 'station') {
+        // STA mode - just refresh data, no radio restart
+        await Future.delayed(const Duration(seconds: 2));
+        try {
+          await fetchDashboardData();
+        } catch (_) {}
+      } else {
+        // AP mode - restart WiFi
+        await _wifiReload(context: context);
+      }
+
+      return true;
+    } catch (e, stack) {
+      Logger.exception('Failed to delete wireless interface', e, stack);
+      _dashboardError = 'Failed to delete interface: $e';
       notifyListeners();
       return false;
     }

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -2004,6 +2004,20 @@ class AppState extends ChangeNotifier {
           if (!isDuplicate) {
             Logger.exception(
               'Failed to create network interface $staNetworkName; aborting connect', e, StackTrace.current);
+            // Roll back the wifi-iface section that was just staged so a
+            // subsequent wireless commit cannot activate an orphaned station
+            // that references the missing network interface.
+            try {
+              await _apiService!.uciDelete(
+                ip, auth, https,
+                config: 'wireless',
+                section: sectionName,
+                context: context,
+              );
+              Logger.info('Rolled back staged wifi-iface section: $sectionName');
+            } catch (rollbackErr) {
+              Logger.warning('Could not roll back wifi-iface $sectionName: $rollbackErr');
+            }
             _dashboardError = 'Failed to create network interface: $e';
             notifyListeners();
             return false;

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -2006,6 +2006,15 @@ class AppState extends ChangeNotifier {
       if (wirelessSections == null) {
         throw const FormatException('Invalid wireless configuration response');
       }
+      final radio = wirelessSections[radioDevice];
+      if (radio is! Map) {
+        throw FormatException('Radio $radioDevice not found');
+      }
+      if (_isUciDisabled(radio['disabled'])) {
+        _dashboardError = 'Enable $radioDevice before connecting';
+        notifyListeners();
+        return false;
+      }
 
       String? existingStaSection;
       Map? existingStaConfig;
@@ -2307,6 +2316,7 @@ class AppState extends ChangeNotifier {
         final canRemoveDependencies =
             (!createdStation && !updatedStation) || wirelessRolledBack;
         if (canRemoveDependencies) {
+          var wanMembershipRolledBack = !addedToWan;
           if (addedToWan) {
             await attemptRollback('WAN firewall membership', () async {
               await _apiService!.systemExec(
@@ -2327,10 +2337,11 @@ class AppState extends ChangeNotifier {
                 config: 'firewall',
                 context: context?.mounted == true ? context : null,
               );
+              wanMembershipRolledBack = true;
             });
           }
 
-          if (createdNetwork) {
+          if (createdNetwork && wanMembershipRolledBack) {
             await attemptRollback(
               'network interface $staNetworkName',
               () async {
@@ -2350,6 +2361,11 @@ class AppState extends ChangeNotifier {
                   context: context?.mounted == true ? context : null,
                 );
               },
+            );
+          } else if (createdNetwork) {
+            rollbackErrors.add(
+              'kept network interface $staNetworkName because WAN firewall '
+              'membership could not be removed',
             );
           }
         } else {

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1551,24 +1551,28 @@ class AppState extends ChangeNotifier {
     final ip = _authService!.ipAddress!;
     final auth = _authService!.sysauth!;
     final https = _authService!.useHttps;
-    final safeCtx = context?.mounted == true ? context : null;
-
     // Disable — failure here is acceptable (radio was already up).
     try {
       await _apiService!.uciSet(
-        ip, auth, https,
+        ip,
+        auth,
+        https,
         config: 'wireless',
         section: radioName,
         values: {'disabled': '1'},
-        context: safeCtx,
+        context: context,
       );
       await _apiService!.uciCommit(
-        ip, auth, https,
+        ip,
+        auth,
+        https,
         config: 'wireless',
-        context: safeCtx,
+        context: context?.mounted == true ? context : null,
       );
     } catch (e) {
-      Logger.warning('Radio disable failed for $radioName: $e — aborting restart');
+      Logger.warning(
+        'Radio disable failed for $radioName: $e — aborting restart',
+      );
       rethrow;
     }
 
@@ -1576,16 +1580,20 @@ class AppState extends ChangeNotifier {
 
     // Re-enable — must not suppress: a failure here leaves the radio disabled.
     await _apiService!.uciSet(
-      ip, auth, https,
+      ip,
+      auth,
+      https,
       config: 'wireless',
       section: radioName,
       values: {'disabled': '0'},
-      context: safeCtx,
+      context: context?.mounted == true ? context : null,
     );
     await _apiService!.uciCommit(
-      ip, auth, https,
+      ip,
+      auth,
+      https,
       config: 'wireless',
-      context: safeCtx,
+      context: context?.mounted == true ? context : null,
     );
 
     await Future.delayed(Duration(seconds: delaySeconds));
@@ -1598,9 +1606,7 @@ class AppState extends ChangeNotifier {
   /// Helper: restarts all known radios via UCI disable/enable cycle.
   /// Used after operations that need wifi to reload (toggle, modify, delete).
   /// Never throws.
-  Future<void> _wifiReload({
-    BuildContext? context,
-  }) async {
+  Future<void> _wifiReload({BuildContext? context}) async {
     // Get list of radios from dashboard data
     final wirelessData =
         _dashboardData?['wireless'] as Map<String, dynamic>? ?? {};
@@ -1727,7 +1733,7 @@ class AppState extends ChangeNotifier {
             sysauth: _authService!.sysauth!,
             useHttps: _authService!.useHttps,
             device: phyName,
-            context: context,
+            context: context?.mounted == true ? context : null,
           );
           if (retryResults.isNotEmpty) {
             return retryResults.map((r) => WifiScanResult.fromJson(r)).toList()
@@ -1766,10 +1772,16 @@ class AppState extends ChangeNotifier {
         if (freq is int) {
           // Valid Wi-Fi ranges: 2.4 GHz (2400–2500), 4.9 GHz (4900–5000),
           // 5 GHz (5000–5925), 6 GHz (5925–7125).
-          final isValidFreq = (freq >= 2400 && freq <= 2500) ||
-              (freq >= 4900 && freq <= 7125);
+          final isValidFreq =
+              (freq >= 2400 && freq <= 2500) || (freq >= 4900 && freq <= 7125);
           if (isValidFreq) {
-            band = freq >= 5925 ? '6 GHz' : freq >= 5000 ? '5 GHz' : freq >= 4900 ? '4.9 GHz' : '2.4 GHz';
+            band = freq >= 5925
+                ? '6 GHz'
+                : freq >= 5000
+                ? '5 GHz'
+                : freq >= 4900
+                ? '4.9 GHz'
+                : '2.4 GHz';
           }
         }
         if (band.isEmpty && channel is int) {
@@ -1788,8 +1800,7 @@ class AppState extends ChangeNotifier {
             final config = iface['config'] as Map<String, dynamic>? ?? {};
             final iwinfo = iface['iwinfo'] as Map<String, dynamic>? ?? {};
             final mode = config['mode']?.toString() ?? '';
-            final ssid =
-                (iwinfo['ssid'] ?? config['ssid'] ?? '').toString();
+            final ssid = (iwinfo['ssid'] ?? config['ssid'] ?? '').toString();
 
             if (bestIfname == null || mode == 'ap') {
               bestIfname = ifname;
@@ -1852,7 +1863,6 @@ class AppState extends ChangeNotifier {
   /// [ssid] is the network SSID to connect to.
   /// [encryption] is the OpenWrt encryption type (e.g., 'psk2', 'sae', 'none').
   /// [password] is the network password (empty for open networks).
-  /// [networkName] is the UCI network name to bind to (defaults to 'wwan').
   Future<bool> connectToWirelessNetwork({
     required String radioDevice,
     required String ssid,
@@ -1881,224 +1891,194 @@ class AppState extends ChangeNotifier {
       final radioIndex = int.tryParse(radioDevice.replaceAll('radio', '')) ?? 0;
       final staNetworkName = radioIndex == 0 ? 'wwan' : 'wwan$radioIndex';
 
-      // Find next available wifinet# name properly
-      String sectionName = 'wifinet0';
-      bool existingStaUpdated = false;
-      
-      try {
-        final uciResult = await _apiService!.uciGetAll(
-          ip, auth, https,
-          config: 'wireless',
-          context: context,
-        );
-        final wirelessSections = _resolveUciSections(uciResult, 'wireless');
-        if (wirelessSections != null) {
-          final wirelessConfig = wirelessSections;
-          final sections = wirelessConfig.keys.toSet();
-
-          // Find existing STA on this radio - if exists, update it
-          String? existingStaOnThisRadio;
-          for (final sectionKey in sections) {
-            final section = wirelessConfig[sectionKey];
-            if (section is Map<String, dynamic>) {
-              final device = section['device']?.toString();
-              final mode = section['mode']?.toString();
-              if (device == radioDevice && mode == 'sta') {
-                existingStaOnThisRadio = sectionKey.toString();
-                break;
-              }
-            }
-          }
-
-          if (existingStaOnThisRadio != null) {
-            // Found existing STA on this radio - update it
-            Logger.info('Found existing STA on $radioDevice, updating section $existingStaOnThisRadio');
-            await _apiService!.uciSet(
-              ip, auth, https,
-              config: 'wireless',
-              section: existingStaOnThisRadio,
-              values: {
-                'network': staNetworkName,
-                'ssid': ssid,
-                'encryption': encryption,
-                if (password.isNotEmpty) 'key': password,
-                if (bssid != null && bssid.isNotEmpty) 'bssid': bssid,
-              },
-              context: context,
-            );
-            existingStaUpdated = true;
-            sectionName = existingStaOnThisRadio;
-          } else {
-            // No existing STA on this radio - create new with proper wifinet#
-            Logger.info('No existing STA on $radioDevice, creating new section');
-            int maxIdx = -1;
-            for (final key in sections) {
-              if (key.toString().startsWith('wifinet')) {
-                final numStr = key.toString().replaceAll('wifinet', '');
-                final num = int.tryParse(numStr);
-                if (num != null && num > maxIdx) {
-                  maxIdx = num;
-                }
-              }
-            }
-            sectionName = 'wifinet${maxIdx + 1}';
-            Logger.info('Selected new section name: $sectionName (max was $maxIdx)');
-          }
-        }
-      } catch (e) {
-        Logger.warning('Could not query existing sections: $e');
+      final wirelessResult = await _apiService!.uciGetAll(
+        ip,
+        auth,
+        https,
+        config: 'wireless',
+        context: context,
+      );
+      final wirelessSections = _resolveUciSections(wirelessResult, 'wireless');
+      if (wirelessSections == null) {
+        throw const FormatException('Invalid wireless configuration response');
       }
 
-      // If we didn't update an existing STA, create new one
-      if (!existingStaUpdated) {
-        Logger.info('Creating new wifi-iface section: $sectionName with network: $staNetworkName');
-
-        final values = <String, dynamic>{
-          'device': radioDevice,
-          'network': staNetworkName,
-          'mode': 'sta',
-          'ssid': ssid,
-          'encryption': encryption,
-        };
-        if (password.isNotEmpty) {
-          values['key'] = password;
+      String? existingStaSection;
+      Map? existingStaConfig;
+      var maxWifinetIndex = -1;
+      for (final entry in wirelessSections.entries) {
+        final section = entry.value;
+        if (entry.key.startsWith('wifinet')) {
+          final index = int.tryParse(entry.key.substring('wifinet'.length));
+          if (index != null && index > maxWifinetIndex) {
+            maxWifinetIndex = index;
+          }
         }
-        if (bssid != null && bssid.isNotEmpty) {
-          values['bssid'] = bssid;
+        if (section is Map &&
+            section['device']?.toString() == radioDevice &&
+            section['mode']?.toString() == 'sta') {
+          existingStaSection = entry.key;
+          existingStaConfig = section;
         }
+      }
+      final sectionName = existingStaSection ?? 'wifinet${maxWifinetIndex + 1}';
 
-        // 1. Add a named wifi-iface section
-        final addResult = await _apiService!.uciAdd(
+      // Persist the dependency first. A wireless station is never staged or
+      // restarted unless its DHCP interface has committed successfully.
+      final networkResult = await _apiService!.uciGetAll(
+        ip,
+        auth,
+        https,
+        config: 'network',
+        context: context?.mounted == true ? context : null,
+      );
+      final networkSections = _resolveUciSections(networkResult, 'network');
+      if (networkSections == null) {
+        throw const FormatException('Invalid network configuration response');
+      }
+      if (!networkSections.containsKey(staNetworkName)) {
+        await _apiService!.uciAdd(
+          ip,
+          auth,
+          https,
+          config: 'network',
+          type: 'interface',
+          name: staNetworkName,
+          values: {'proto': 'dhcp'},
+          context: context?.mounted == true ? context : null,
+        );
+      }
+      await _apiService!.uciCommit(
+        ip,
+        auth,
+        https,
+        config: 'network',
+        context: context?.mounted == true ? context : null,
+      );
+
+      // WAN membership is optional for firewall-less routers, but when a WAN
+      // zone exists, add and commit the station network before wireless.
+      try {
+        final firewallResult = await _apiService!.uciGetAll(
+          ip,
+          auth,
+          https,
+          config: 'firewall',
+          context: context?.mounted == true ? context : null,
+        );
+        final firewallSections = _resolveUciSections(
+          firewallResult,
+          'firewall',
+        );
+        var zoneIndex = 0;
+        var wanZoneIndex = -1;
+        var foundInWan = false;
+        if (firewallSections != null) {
+          for (final entry in firewallSections.entries) {
+            final section = entry.value;
+            if (section is! Map || section['.type']?.toString() != 'zone') {
+              continue;
+            }
+            if (section['name']?.toString() == 'wan') {
+              wanZoneIndex = zoneIndex;
+              final networks = section['network'];
+              foundInWan = networks is List
+                  ? networks
+                        .map((value) => value.toString())
+                        .contains(staNetworkName)
+                  : networks
+                            ?.toString()
+                            .split(RegExp(r'\s+'))
+                            .contains(staNetworkName) ==
+                        true;
+              break;
+            }
+            zoneIndex++;
+          }
+        }
+        if (!foundInWan && wanZoneIndex >= 0) {
+          await _apiService!.systemExec(
+            ip,
+            auth,
+            https,
+            command: '/sbin/uci',
+            params: [
+              'add_list',
+              'firewall.@zone[$wanZoneIndex].network=$staNetworkName',
+            ],
+            context: context?.mounted == true ? context : null,
+          );
+          await _apiService!.uciCommit(
+            ip,
+            auth,
+            https,
+            config: 'firewall',
+            context: context?.mounted == true ? context : null,
+          );
+        }
+      } catch (e) {
+        Logger.warning('Failed to add $staNetworkName to the WAN zone: $e');
+      }
+
+      if (existingStaSection != null) {
+        await _apiService!.uciSet(
+          ip,
+          auth,
+          https,
+          config: 'wireless',
+          section: sectionName,
+          values: {
+            'network': staNetworkName,
+            'ssid': ssid,
+            'encryption': encryption,
+            if (password.isNotEmpty) 'key': password,
+            if (bssid?.isNotEmpty == true) 'bssid': bssid!,
+          },
+          context: context?.mounted == true ? context : null,
+        );
+        if (password.isEmpty && existingStaConfig?.containsKey('key') == true) {
+          await _apiService!.uciDelete(
+            ip,
+            auth,
+            https,
+            config: 'wireless',
+            section: sectionName,
+            option: 'key',
+            context: context?.mounted == true ? context : null,
+          );
+        }
+        if (bssid?.isNotEmpty != true &&
+            existingStaConfig?.containsKey('bssid') == true) {
+          await _apiService!.uciDelete(
+            ip,
+            auth,
+            https,
+            config: 'wireless',
+            section: sectionName,
+            option: 'bssid',
+            context: context?.mounted == true ? context : null,
+          );
+        }
+      } else {
+        await _apiService!.uciAdd(
           ip,
           auth,
           https,
           config: 'wireless',
           type: 'wifi-iface',
           name: sectionName,
-          values: values,
-          context: context,
+          values: {
+            'device': radioDevice,
+            'network': staNetworkName,
+            'mode': 'sta',
+            'ssid': ssid,
+            'encryption': encryption,
+            if (password.isNotEmpty) 'key': password,
+            if (bssid?.isNotEmpty == true) 'bssid': bssid!,
+          },
+          context: context?.mounted == true ? context : null,
         );
-
-        Logger.info('UCI add result: $addResult');
-
-        // 2. Create network interface (always — wwan may not exist on a fresh router).
-        // Only suppress errors that indicate the section already exists; all other
-        // failures mean the network interface was not created and we must stop here
-        // (the station would be committed but reference a non-existent network).
-        try {
-          await _apiService!.uciAdd(
-            ip, auth, https,
-            config: 'network',
-            type: 'interface',
-            name: staNetworkName,
-            values: {'proto': 'dhcp'},
-            context: context,
-          );
-          Logger.info('Created network interface: $staNetworkName');
-        } catch (e) {
-          final msg = e.toString().toLowerCase();
-          final isDuplicate = msg.contains('already exist') ||
-              msg.contains('duplicate') ||
-              msg.contains('entry exists') ||
-              msg.contains('-6'); // EEXIST from ubus
-          if (!isDuplicate) {
-            Logger.exception(
-              'Failed to create network interface $staNetworkName; aborting connect', e, StackTrace.current);
-            // Roll back the wifi-iface section that was just staged so a
-            // subsequent wireless commit cannot activate an orphaned station
-            // that references the missing network interface.
-            bool rolledBack = false;
-            try {
-              await _apiService!.uciDelete(
-                ip, auth, https,
-                config: 'wireless',
-                section: sectionName,
-                context: context,
-              );
-              rolledBack = true;
-              Logger.info('Rolled back staged wifi-iface section: $sectionName');
-            } catch (rollbackErr) {
-              Logger.exception(
-                'Could not roll back wifi-iface $sectionName — orphaned section may be committed by a later wireless commit',
-                rollbackErr,
-                StackTrace.current,
-              );
-            }
-            _dashboardError = rolledBack
-                ? 'Failed to create network interface: $e'
-                : 'Failed to create network interface and rollback failed. '
-                  'Please manually delete wireless section "$sectionName" '
-                  'before the next wireless commit.';
-            notifyListeners();
-            return false;
-          }
-          Logger.warning('Network interface $staNetworkName already exists, continuing');
-        }
-        
-        // 3. Add to firewall WAN zone if not already there
-        try {
-          final firewallResult = await _apiService!.uciGetAll(
-            ip, auth, https,
-            config: 'firewall',
-            context: context,
-          );
-          bool foundInWan = false;
-          int wanZoneIndex = -1;
-          final firewallSections = _resolveUciSections(firewallResult, 'firewall');
-          if (firewallSections != null) {
-            final firewallConfig = firewallSections;
-            int zoneIndex = 0;
-            for (final key in firewallConfig.keys) {
-              final section = firewallConfig[key];
-              if (section is Map<String, dynamic>) {
-                final typeName = section['.type']?.toString() ?? key.toString().split('@').first;
-                // Check if this is a zone section
-                if (typeName == 'zone' || (section.containsKey('name') && section.containsKey('input'))) {
-                  final zoneName = section['name']?.toString();
-                  if (zoneName == 'wan') {
-                    wanZoneIndex = zoneIndex;
-                    // Check if network is already in this zone — use token comparison
-                    final networks = section['network'];
-                    if (networks is String) {
-                      // Split space-separated UCI network list for exact token match
-                      final tokens = networks.split(RegExp(r'\s+'));
-                      if (tokens.contains(staNetworkName)) {
-                        foundInWan = true;
-                        break;
-                      }
-                    } else if (networks is List && networks.map((e) => e.toString()).contains(staNetworkName)) {
-                      foundInWan = true;
-                      break;
-                    }
-                  }
-                  zoneIndex++;
-                }
-              }
-            }
-          }
-
-          if (!foundInWan && wanZoneIndex >= 0) {
-            // Use system command to add network to wan zone
-            // The systemExec splits by whitespace, so we pass each part separately
-            await _apiService!.systemExec(
-              ip, auth, https,
-              command: "uci add_list firewall.@zone[$wanZoneIndex].network=$staNetworkName",
-              context: context,
-            );
-            // Commit firewall changes
-            await _apiService!.uciCommit(
-              ip, auth, https,
-              config: 'firewall',
-              context: context,
-            );
-            Logger.info('Added $staNetworkName to WAN firewall zone at index $wanZoneIndex');
-          }
-        } catch (e) {
-          Logger.warning('Failed to add to firewall zone: $e');
-        }
       }
-
-      // 4. Commit wireless configuration
       await _apiService!.uciCommit(
         ip,
         auth,
@@ -2107,28 +2087,10 @@ class AppState extends ChangeNotifier {
         context: context?.mounted == true ? context : null,
       );
 
-      // 5. Commit network and firewall configuration
-      try {
-        await _apiService!.uciCommit(
-          ip, auth, https,
-          config: 'network',
-          context: context?.mounted == true ? context : null,
-        );
-      } catch (e) {
-        Logger.warning('Network commit failed: $e');
-      }
-      try {
-        await _apiService!.uciCommit(
-          ip, auth, https,
-          config: 'firewall',
-          context: context?.mounted == true ? context : null,
-        );
-      } catch (e) {
-        Logger.warning('Firewall commit failed: $e');
-      }
-
-      // 6. Restart radio to apply changes
-      await _restartRadioViaUci(radioDevice, context: context);
+      await _restartRadioViaUci(
+        radioDevice,
+        context: context?.mounted == true ? context : null,
+      );
 
       return true;
     } catch (e, stack) {
@@ -2159,7 +2121,9 @@ class AppState extends ChangeNotifier {
     }
 
     try {
-      Logger.info('Toggle interface $uciSection → ${enabled ? 'enabled' : 'disabled'}');
+      Logger.info(
+        'Toggle interface $uciSection → ${enabled ? 'enabled' : 'disabled'}',
+      );
 
       await _apiService!.uciSet(
         _authService!.ipAddress!,
@@ -2192,9 +2156,13 @@ class AppState extends ChangeNotifier {
     // Reload failure is handled here so the UI can show the snackbar
     // and the toggle row does not remain stuck in its transitioning state.
     try {
-      await _wifiReload(context: context);
+      await _wifiReload(context: context?.mounted == true ? context : null);
     } catch (e, stack) {
-      Logger.exception('Wireless reload failed after toggle (interface may still be disabled)', e, stack);
+      Logger.exception(
+        'Wireless reload failed after toggle (interface may still be disabled)',
+        e,
+        stack,
+      );
       _dashboardError = 'Interface toggled but wireless reload failed: $e';
       notifyListeners();
       return false;
@@ -2241,7 +2209,7 @@ class AppState extends ChangeNotifier {
         context: context?.mounted == true ? context : null,
       );
 
-      await _wifiReload(context: context);
+      await _wifiReload(context: context?.mounted == true ? context : null);
 
       return true;
     } catch (e, stack) {
@@ -2290,7 +2258,7 @@ class AppState extends ChangeNotifier {
       );
 
       // Only reload WiFi for AP mode - STA deletion doesn't require radio restart
-      if (mode.toLowerCase().contains('sta') || 
+      if (mode.toLowerCase().contains('sta') ||
           mode.toLowerCase().contains('client') ||
           mode.toLowerCase() == 'station') {
         // STA mode - just refresh data, no radio restart
@@ -2300,7 +2268,7 @@ class AppState extends ChangeNotifier {
         } catch (_) {}
       } else {
         // AP mode - restart WiFi
-        await _wifiReload(context: context);
+        await _wifiReload(context: context?.mounted == true ? context : null);
       }
 
       return true;

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1546,6 +1546,10 @@ class AppState extends ChangeNotifier {
     return Map<String, dynamic>.from(outer);
   }
 
+  bool _isUciDisabled(dynamic value) => value is List
+      ? value.any(_isUciDisabled)
+      : value == true || value?.toString() == '1';
+
   /// Restarts a specific radio via UCI disable/enable cycle.
   /// This is more reliable than `wifi reload` which doesn't work on all routers.
   /// Throws if the re-enable step fails (leaving the radio disabled is worse
@@ -1679,15 +1683,12 @@ class AppState extends ChangeNotifier {
     if (sections == null) {
       throw const FormatException('Invalid wireless configuration response');
     }
-    bool isDisabled(dynamic value) => value is List
-        ? value.any(isDisabled)
-        : value == true || value?.toString() == '1';
     final radios = sections.entries
         .where(
           (entry) =>
               entry.value is Map &&
               entry.value['.type']?.toString() == 'wifi-device' &&
-              !isDisabled(entry.value['disabled']),
+              !_isUciDisabled(entry.value['disabled']),
         )
         .map((entry) => entry.key)
         .toList();
@@ -1929,8 +1930,28 @@ class AppState extends ChangeNotifier {
     }
 
     try {
+      final result = await _apiService!.uciGetAll(
+        _authService!.ipAddress!,
+        _authService!.sysauth!,
+        _authService!.useHttps,
+        config: 'wireless',
+        context: context,
+      );
+      final sections = _resolveUciSections(result, 'wireless');
+      final radio = sections?[radioName];
+      if (radio is! Map) {
+        throw FormatException('Radio $radioName not found');
+      }
+      if (_isUciDisabled(radio['disabled'])) {
+        _dashboardError = 'Enable $radioName before restarting it';
+        notifyListeners();
+        return false;
+      }
       Logger.info('Restarting radio $radioName via UCI cycle');
-      await _restartRadioViaUci(radioName, context: context);
+      await _restartRadioViaUci(
+        radioName,
+        context: context?.mounted == true ? context : null,
+      );
       return true;
     } catch (e, stack) {
       Logger.exception('Failed to restart radio $radioName', e, stack);

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1668,23 +1668,45 @@ class AppState extends ChangeNotifier {
   /// Used after operations that need wifi to reload (toggle, modify, delete).
   /// Propagates restart failures so callers cannot report stale runtime state.
   Future<void> _wifiReload({BuildContext? context}) async {
-    // Get list of radios from dashboard data
-    final wirelessData =
-        _dashboardData?['wireless'] as Map<String, dynamic>? ?? {};
-    final radios = wirelessData.keys.toList();
+    final result = await _apiService!.uciGetAll(
+      _authService!.ipAddress!,
+      _authService!.sysauth!,
+      _authService!.useHttps,
+      config: 'wireless',
+      context: context,
+    );
+    final sections = _resolveUciSections(result, 'wireless');
+    if (sections == null) {
+      throw const FormatException('Invalid wireless configuration response');
+    }
+    bool isDisabled(dynamic value) => value is List
+        ? value.any(isDisabled)
+        : value == true || value?.toString() == '1';
+    final radios = sections.entries
+        .where(
+          (entry) =>
+              entry.value is Map &&
+              entry.value['.type']?.toString() == 'wifi-device' &&
+              !isDisabled(entry.value['disabled']),
+        )
+        .map((entry) => entry.key)
+        .toList();
 
     if (radios.isEmpty) {
-      Logger.warning('_wifiReload: no radios found in dashboard data');
-      await Future.delayed(const Duration(seconds: 4));
+      Logger.info('_wifiReload: no enabled radios to restart');
       try {
         await fetchDashboardData();
       } catch (_) {}
       return;
     }
 
-    // Cycle all radios
+    // Cycle only enabled radios; disabled radios must remain disabled.
     for (final radio in radios) {
-      await _restartRadioViaUci(radio, context: context, delaySeconds: 3);
+      await _restartRadioViaUci(
+        radio,
+        context: context?.mounted == true ? context : null,
+        delaySeconds: 3,
+      );
     }
   }
 

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1757,14 +1757,22 @@ class AppState extends ChangeNotifier {
       if (radioData is Map<String, dynamic>) {
         final interfaces = radioData['interfaces'] as List<dynamic>?;
 
-        // Determine band from frequency/channel
+        // Determine band from frequency/channel.
+        // Only accept frequencies within known Wi-Fi ranges (MHz);
+        // out-of-range values fall through to channel-based classification.
         final freq = radioData['frequency'];
         final channel = radioData['channel'];
         String band = '';
         if (freq is int) {
-          // Check 6 GHz before 5 GHz — 6 GHz starts at 5925 MHz
-          band = freq >= 5925 ? '6 GHz' : freq >= 5000 ? '5 GHz' : freq >= 4000 ? '4 GHz' : '2.4 GHz';
-        } else if (channel is int) {
+          // Valid Wi-Fi ranges: 2.4 GHz (2400–2500), 4.9 GHz (4900–5000),
+          // 5 GHz (5000–5925), 6 GHz (5925–7125).
+          final isValidFreq = (freq >= 2400 && freq <= 2500) ||
+              (freq >= 4900 && freq <= 7125);
+          if (isValidFreq) {
+            band = freq >= 5925 ? '6 GHz' : freq >= 5000 ? '5 GHz' : freq >= 4000 ? '4 GHz' : '2.4 GHz';
+          }
+        }
+        if (band.isEmpty && channel is int) {
           // Frequency-based is preferred; channel fallback can't distinguish 6 GHz
           band = channel >= 36 ? '5 GHz' : '2.4 GHz';
         }

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1769,7 +1769,7 @@ class AppState extends ChangeNotifier {
           final isValidFreq = (freq >= 2400 && freq <= 2500) ||
               (freq >= 4900 && freq <= 7125);
           if (isValidFreq) {
-            band = freq >= 5925 ? '6 GHz' : freq >= 5000 ? '5 GHz' : freq >= 4000 ? '4 GHz' : '2.4 GHz';
+            band = freq >= 5925 ? '6 GHz' : freq >= 5000 ? '5 GHz' : freq >= 4900 ? '4.9 GHz' : '2.4 GHz';
           }
         }
         if (band.isEmpty && channel is int) {

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -2007,6 +2007,7 @@ class AppState extends ChangeNotifier {
             // Roll back the wifi-iface section that was just staged so a
             // subsequent wireless commit cannot activate an orphaned station
             // that references the missing network interface.
+            bool rolledBack = false;
             try {
               await _apiService!.uciDelete(
                 ip, auth, https,
@@ -2014,11 +2015,20 @@ class AppState extends ChangeNotifier {
                 section: sectionName,
                 context: context,
               );
+              rolledBack = true;
               Logger.info('Rolled back staged wifi-iface section: $sectionName');
             } catch (rollbackErr) {
-              Logger.warning('Could not roll back wifi-iface $sectionName: $rollbackErr');
+              Logger.exception(
+                'Could not roll back wifi-iface $sectionName — orphaned section may be committed by a later wireless commit',
+                rollbackErr,
+                StackTrace.current,
+              );
             }
-            _dashboardError = 'Failed to create network interface: $e';
+            _dashboardError = rolledBack
+                ? 'Failed to create network interface: $e'
+                : 'Failed to create network interface and rollback failed. '
+                  'Please manually delete wireless section "$sectionName" '
+                  'before the next wireless commit.';
             notifyListeners();
             return false;
           }
@@ -2178,8 +2188,17 @@ class AppState extends ChangeNotifier {
       return false;
     }
 
-    // UCI changes are committed — reload wireless to apply at runtime
-    await _wifiReload(context: context);
+    // UCI changes are committed — reload wireless to apply at runtime.
+    // Reload failure is handled here so the UI can show the snackbar
+    // and the toggle row does not remain stuck in its transitioning state.
+    try {
+      await _wifiReload(context: context);
+    } catch (e, stack) {
+      Logger.exception('Wireless reload failed after toggle (interface may still be disabled)', e, stack);
+      _dashboardError = 'Interface toggled but wireless reload failed: $e';
+      notifyListeners();
+      return false;
+    }
     Logger.info('Toggle interface $uciSection complete');
     return true;
   }

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1518,7 +1518,8 @@ class AppState extends ChangeNotifier {
 
   /// Restarts a specific radio via UCI disable/enable cycle.
   /// This is more reliable than `wifi reload` which doesn't work on all routers.
-  /// Never throws — failures are logged but don't fail the calling operation.
+  /// Throws if the re-enable step fails (leaving the radio disabled is worse
+  /// than surfacing the error to the caller).
   Future<void> _restartRadioViaUci(
     String radioName, {
     BuildContext? context,
@@ -1529,8 +1530,8 @@ class AppState extends ChangeNotifier {
     final https = _authService!.useHttps;
     final safeCtx = context?.mounted == true ? context : null;
 
+    // Disable — failure here is acceptable (radio was already up).
     try {
-      // Disable the radio
       await _apiService!.uciSet(
         ip, auth, https,
         config: 'wireless',
@@ -1543,27 +1544,28 @@ class AppState extends ChangeNotifier {
         config: 'wireless',
         context: safeCtx,
       );
-
-      await Future.delayed(Duration(seconds: delaySeconds));
-
-      // Re-enable the radio
-      await _apiService!.uciSet(
-        ip, auth, https,
-        config: 'wireless',
-        section: radioName,
-        values: {'disabled': '0'},
-        context: safeCtx,
-      );
-      await _apiService!.uciCommit(
-        ip, auth, https,
-        config: 'wireless',
-        context: safeCtx,
-      );
-
-      await Future.delayed(Duration(seconds: delaySeconds));
     } catch (e) {
-      Logger.warning('Radio restart via UCI failed for $radioName: $e');
+      Logger.warning('Radio disable failed for $radioName: $e — aborting restart');
+      rethrow;
     }
+
+    await Future.delayed(Duration(seconds: delaySeconds));
+
+    // Re-enable — must not suppress: a failure here leaves the radio disabled.
+    await _apiService!.uciSet(
+      ip, auth, https,
+      config: 'wireless',
+      section: radioName,
+      values: {'disabled': '0'},
+      context: safeCtx,
+    );
+    await _apiService!.uciCommit(
+      ip, auth, https,
+      config: 'wireless',
+      context: safeCtx,
+    );
+
+    await Future.delayed(Duration(seconds: delaySeconds));
 
     try {
       await fetchDashboardData();
@@ -1737,8 +1739,10 @@ class AppState extends ChangeNotifier {
         final channel = radioData['channel'];
         String band = '';
         if (freq is int) {
-          band = freq >= 5000 ? '5 GHz' : freq >= 4000 ? '4 GHz' : '2.4 GHz';
+          // Check 6 GHz before 5 GHz — 6 GHz starts at 5925 MHz
+          band = freq >= 5925 ? '6 GHz' : freq >= 5000 ? '5 GHz' : freq >= 4000 ? '4 GHz' : '2.4 GHz';
         } else if (channel is int) {
+          // Frequency-based is preferred; channel fallback can't distinguish 6 GHz
           band = channel >= 36 ? '5 GHz' : '2.4 GHz';
         }
 
@@ -1856,8 +1860,20 @@ class AppState extends ChangeNotifier {
           config: 'wireless',
           context: context,
         );
-        if (uciResult is List && uciResult.length > 1 && uciResult[1] is Map) {
-          final wirelessConfig = uciResult[1] as Map<String, dynamic>;
+        // Unwrap LuCI's [status, {values: {...}}] response shape.
+        // Real API returns result[1]['values'], mock returns result[1]['wireless'].
+        Map<String, dynamic>? _resolveUciSections(dynamic uciResult) {
+          if (uciResult is! List || uciResult.length < 2) return null;
+          final outer = uciResult[1];
+          if (outer is! Map) return null;
+          if (outer['values'] is Map) return Map<String, dynamic>.from(outer['values'] as Map);
+          if (outer['wireless'] is Map) return Map<String, dynamic>.from(outer['wireless'] as Map);
+          // Flat map (some implementations return sections directly)
+          return Map<String, dynamic>.from(outer);
+        }
+        final wirelessSections = _resolveUciSections(uciResult);
+        if (wirelessSections != null) {
+          final wirelessConfig = wirelessSections;
           final sections = wirelessConfig.keys.toSet();
 
           // Find existing STA on this radio - if exists, update it
@@ -1945,21 +1961,19 @@ class AppState extends ChangeNotifier {
 
         Logger.info('UCI add result: $addResult');
 
-        // 2. Create network interface if needed (for wwan1, wwan2, etc.)
-        if (staNetworkName != 'wwan') {
-          try {
-            await _apiService!.uciAdd(
-              ip, auth, https,
-              config: 'network',
-              type: 'interface',
-              name: staNetworkName,
-              values: {'proto': 'dhcp'},
-              context: context,
-            );
-            Logger.info('Created network interface: $staNetworkName');
-          } catch (e) {
-            Logger.warning('Network interface may already exist: $e');
-          }
+        // 2. Create network interface (always — wwan may not exist on a fresh router)
+        try {
+          await _apiService!.uciAdd(
+            ip, auth, https,
+            config: 'network',
+            type: 'interface',
+            name: staNetworkName,
+            values: {'proto': 'dhcp'},
+            context: context,
+          );
+          Logger.info('Created network interface: $staNetworkName');
+        } catch (e) {
+          Logger.warning('Network interface may already exist: $e');
         }
         
         // 3. Add to firewall WAN zone if not already there
@@ -1971,8 +1985,18 @@ class AppState extends ChangeNotifier {
           );
           bool foundInWan = false;
           int wanZoneIndex = -1;
+          // Resolve sections (same unwrap logic as wireless config above)
+          Map<String, dynamic>? firewallSections;
           if (firewallResult is List && firewallResult.length > 1 && firewallResult[1] is Map) {
-            final firewallConfig = firewallResult[1] as Map<String, dynamic>;
+            final outer = firewallResult[1] as Map<String, dynamic>;
+            if (outer['values'] is Map) {
+              firewallSections = Map<String, dynamic>.from(outer['values'] as Map);
+            } else {
+              firewallSections = Map<String, dynamic>.from(outer);
+            }
+          }
+          if (firewallSections != null) {
+            final firewallConfig = firewallSections;
             int zoneIndex = 0;
             for (final key in firewallConfig.keys) {
               final section = firewallConfig[key];
@@ -1983,15 +2007,16 @@ class AppState extends ChangeNotifier {
                   final zoneName = section['name']?.toString();
                   if (zoneName == 'wan') {
                     wanZoneIndex = zoneIndex;
-                    // Check if network is already in this zone
+                    // Check if network is already in this zone — use token comparison
                     final networks = section['network'];
-                    if (networks is String && networks == staNetworkName) {
-                      foundInWan = true;
-                      break;
-                    } else if (networks is String && networks.contains(staNetworkName)) {
-                      foundInWan = true;
-                      break;
-                    } else if (networks is List && networks.contains(staNetworkName)) {
+                    if (networks is String) {
+                      // Split space-separated UCI network list for exact token match
+                      final tokens = networks.split(RegExp(r'\s+'));
+                      if (tokens.contains(staNetworkName)) {
+                        foundInWan = true;
+                        break;
+                      }
+                    } else if (networks is List && networks.map((e) => e.toString()).contains(staNetworkName)) {
                       foundInWan = true;
                       break;
                     }
@@ -2113,11 +2138,8 @@ class AppState extends ChangeNotifier {
       return false;
     }
 
-    // UCI changes are committed — wait and refresh (don't cycle radios for toggle)
-    await Future.delayed(const Duration(seconds: 4));
-    try {
-      await fetchDashboardData();
-    } catch (_) {}
+    // UCI changes are committed — reload wireless to apply at runtime
+    await _wifiReload(context: context);
     Logger.info('Toggle interface $uciSection complete');
     return true;
   }

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1551,7 +1551,7 @@ class AppState extends ChangeNotifier {
     final ip = _authService!.ipAddress!;
     final auth = _authService!.sysauth!;
     final https = _authService!.useHttps;
-    // Disable — failure here is acceptable (radio was already up).
+    // Persist and apply the disabled state before re-enabling the radio.
     try {
       await _apiService!.uciSet(
         ip,
@@ -1567,6 +1567,14 @@ class AppState extends ChangeNotifier {
         auth,
         https,
         config: 'wireless',
+        context: context?.mounted == true ? context : null,
+      );
+      await _apiService!.systemExec(
+        ip,
+        auth,
+        https,
+        command: '/sbin/wifi',
+        params: ['down', radioName],
         context: context?.mounted == true ? context : null,
       );
     } catch (e) {
@@ -1588,6 +1596,14 @@ class AppState extends ChangeNotifier {
       values: {'disabled': '0'},
       context: context?.mounted == true ? context : null,
     );
+    await _apiService!.systemExec(
+      ip,
+      auth,
+      https,
+      command: '/sbin/wifi',
+      params: ['up', radioName],
+      context: context?.mounted == true ? context : null,
+    );
     await _apiService!.uciCommit(
       ip,
       auth,
@@ -1605,7 +1621,7 @@ class AppState extends ChangeNotifier {
 
   /// Helper: restarts all known radios via UCI disable/enable cycle.
   /// Used after operations that need wifi to reload (toggle, modify, delete).
-  /// Never throws.
+  /// Propagates restart failures so callers cannot report stale runtime state.
   Future<void> _wifiReload({BuildContext? context}) async {
     // Get list of radios from dashboard data
     final wirelessData =
@@ -2223,10 +2239,8 @@ class AppState extends ChangeNotifier {
   /// Deletes a wifi-iface UCI section.
   ///
   /// [uciSection] is the UCI section name to remove.
-  /// [mode] is the interface mode ('ap' or 'sta') - if 'ap', WiFi will reload.
   Future<bool> deleteWirelessInterface(
     String uciSection, {
-    String mode = 'ap',
     BuildContext? context,
   }) async {
     if (_reviewerModeEnabled) {
@@ -2257,19 +2271,7 @@ class AppState extends ChangeNotifier {
         context: context?.mounted == true ? context : null,
       );
 
-      // Only reload WiFi for AP mode - STA deletion doesn't require radio restart
-      if (mode.toLowerCase().contains('sta') ||
-          mode.toLowerCase().contains('client') ||
-          mode.toLowerCase() == 'station') {
-        // STA mode - just refresh data, no radio restart
-        await Future.delayed(const Duration(seconds: 2));
-        try {
-          await fetchDashboardData();
-        } catch (_) {}
-      } else {
-        // AP mode - restart WiFi
-        await _wifiReload(context: context?.mounted == true ? context : null);
-      }
+      await _wifiReload(context: context?.mounted == true ? context : null);
 
       return true;
     } catch (e, stack) {

--- a/test/api_service_uci_test.dart
+++ b/test/api_service_uci_test.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:luci_mobile/services/api_service.dart';
+
+void main() {
+  test('UCI calls reject errors and can delete a single option', () async {
+    final requests = <Map<String, dynamic>>[];
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() => server.close(force: true));
+    server.listen((request) async {
+      final payload = jsonDecode(await utf8.decoder.bind(request).join());
+      requests.add(Map<String, dynamic>.from(payload));
+      final method = payload['params'][2];
+      request.response.headers.contentType = ContentType.json;
+      request.response.write(
+        jsonEncode({
+          'jsonrpc': '2.0',
+          'id': 1,
+          'result': method == 'delete' ? [0, {}] : [4, 'forced failure'],
+        }),
+      );
+      await request.response.close();
+    });
+
+    final service = RealApiService();
+    final host = '127.0.0.1:${server.port}';
+    await service.uciDelete(
+      host,
+      'token',
+      false,
+      config: 'wireless',
+      section: 'wifinet0',
+      option: 'key',
+    );
+    expect(requests.single['params'][3]['option'], 'key');
+
+    await expectLater(
+      service.uciCommit(host, 'token', false, config: 'network'),
+      throwsA(
+        isA<Exception>().having(
+          (error) => error.toString(),
+          'message',
+          contains('uci.commit failed: forced failure'),
+        ),
+      ),
+    );
+  });
+}

--- a/test/api_service_uci_test.dart
+++ b/test/api_service_uci_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -18,7 +19,14 @@ void main() {
         jsonEncode({
           'jsonrpc': '2.0',
           'id': 1,
-          'result': method == 'delete' ? [0, {}] : [4, 'forced failure'],
+          'result': method == 'delete'
+              ? [0, {}]
+              : method == 'exec'
+              ? [
+                  0,
+                  {'code': 1, 'stderr': 'forced exit'},
+                ]
+              : [4, 'forced failure'],
         }),
       );
       await request.response.close();
@@ -46,5 +54,50 @@ void main() {
         ),
       ),
     );
+
+    await expectLater(
+      service.systemExec(host, 'token', false, command: '/sbin/false'),
+      throwsA(
+        isA<Exception>().having(
+          (error) => error.toString(),
+          'message',
+          contains('file.exec failed: forced exit'),
+        ),
+      ),
+    );
+  });
+
+  test('a stale scan cannot clear the active cancellation token', () async {
+    final firstRequest = Completer<HttpRequest>();
+    final secondRequest = Completer<HttpRequest>();
+    var requestCount = 0;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() => server.close(force: true));
+    server.listen((request) async {
+      await utf8.decoder.bind(request).join();
+      (requestCount++ == 0 ? firstRequest : secondRequest).complete(request);
+    });
+
+    final service = RealApiService();
+    final host = '127.0.0.1:${server.port}';
+    final firstScan = service.scanWirelessNetworks(
+      ipAddress: host,
+      sysauth: 'token',
+      useHttps: false,
+      device: 'radio0',
+    );
+    await firstRequest.future;
+
+    final secondScan = service.scanWirelessNetworks(
+      ipAddress: host,
+      sysauth: 'token',
+      useHttps: false,
+      device: 'radio1',
+    );
+    await secondRequest.future;
+    expect(await firstScan.timeout(const Duration(seconds: 1)), isEmpty);
+
+    service.cancelScan();
+    expect(await secondScan.timeout(const Duration(seconds: 1)), isEmpty);
   });
 }

--- a/test/wifi_scan_result_test.dart
+++ b/test/wifi_scan_result_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:luci_mobile/models/wifi_scan_result.dart';
+
+void main() {
+  test('classifies the 4.9 GHz Wi-Fi band', () {
+    final result = WifiScanResult.fromJson({
+      'frequency': 4940,
+      'encryption': <String, dynamic>{},
+    });
+
+    expect(result.band, '4.9 GHz');
+  });
+}

--- a/test/wireless_connection_rollback_test.dart
+++ b/test/wireless_connection_rollback_test.dart
@@ -9,11 +9,13 @@ class _FailingRestartApiService extends MockApiService {
   _FailingRestartApiService({
     this.failWirelessDelete = false,
     this.failFirewallRead = false,
+    this.failWanDelete = false,
     this.radioDisabled = false,
   });
 
   final bool failWirelessDelete;
   final bool failFirewallRead;
+  final bool failWanDelete;
   final bool radioDisabled;
   final calls = <String>[];
 
@@ -120,6 +122,9 @@ class _FailingRestartApiService extends MockApiService {
   }) async {
     final call = '$command ${params.join(' ')}';
     calls.add(call);
+    if (failWanDelete && call.startsWith('/sbin/uci del_list firewall.')) {
+      throw Exception('forced WAN membership rollback failure');
+    }
     if (call == '/sbin/wifi down radio0') {
       throw Exception('forced restart failure');
     }
@@ -204,6 +209,50 @@ void main() {
     expect(api.calls, contains('delete network.wwan'));
     expect(api.calls, isNot(contains('add wireless.wifinet0')));
     expect(state.dashboardError, contains('timed out'));
+  });
+
+  test('disabled radio rejects connection before mutation', () async {
+    final api = _FailingRestartApiService(radioDisabled: true);
+    final state = AppState.forTesting(
+      apiService: api,
+      authService: MockAuthService(),
+    );
+    addTearDown(state.dispose);
+
+    final connected = await state.connectToWirelessNetwork(
+      radioDevice: 'radio0',
+      ssid: 'Test network',
+      encryption: 'psk2',
+      password: 'password123',
+    );
+
+    expect(connected, isFalse);
+    expect(api.calls, isEmpty);
+    expect(state.dashboardError, contains('Enable radio0'));
+  });
+
+  test('failed WAN cleanup retains the new network interface', () async {
+    final api = _FailingRestartApiService(failWanDelete: true);
+    final state = AppState.forTesting(
+      apiService: api,
+      authService: MockAuthService(),
+    );
+    addTearDown(state.dispose);
+
+    final connected = await state.connectToWirelessNetwork(
+      radioDevice: 'radio0',
+      ssid: 'Test network',
+      encryption: 'psk2',
+      password: 'password123',
+    );
+
+    expect(connected, isFalse);
+    expect(
+      api.calls,
+      contains('/sbin/uci del_list firewall.@zone[1].network=wwan'),
+    );
+    expect(api.calls, isNot(contains('delete network.wwan')));
+    expect(state.dashboardError, contains('kept network interface wwan'));
   });
 
   test('interface reload leaves disabled radios disabled', () async {

--- a/test/wireless_connection_rollback_test.dart
+++ b/test/wireless_connection_rollback_test.dart
@@ -5,9 +5,13 @@ import 'package:luci_mobile/services/mock_auth_service.dart';
 import 'package:luci_mobile/state/app_state.dart';
 
 class _FailingRestartApiService extends MockApiService {
-  _FailingRestartApiService({this.failWirelessDelete = false});
+  _FailingRestartApiService({
+    this.failWirelessDelete = false,
+    this.radioDisabled = false,
+  });
 
   final bool failWirelessDelete;
+  final bool radioDisabled;
   final calls = <String>[];
 
   @override
@@ -20,7 +24,7 @@ class _FailingRestartApiService extends MockApiService {
   }) async {
     final values = switch (config) {
       'wireless' => {
-        'radio0': {'.type': 'wifi-device'},
+        'radio0': {'.type': 'wifi-device', if (radioDisabled) 'disabled': '1'},
       },
       'network' => {
         'lan': {'.type': 'interface'},
@@ -172,5 +176,21 @@ void main() {
       isNot(contains('/sbin/uci del_list firewall.@zone[1].network=wwan')),
     );
     expect(api.calls, isNot(contains('delete network.wwan')));
+  });
+
+  test('interface reload leaves disabled radios disabled', () async {
+    final api = _FailingRestartApiService(radioDisabled: true);
+    final state = AppState.forTesting(
+      apiService: api,
+      authService: MockAuthService(),
+    );
+    addTearDown(state.dispose);
+
+    final modified = await state.modifyWirelessInterface('wifinet0', {
+      'ssid': 'Updated network',
+    });
+
+    expect(modified, isTrue);
+    expect(api.calls.where((call) => call.startsWith('/sbin/wifi ')), isEmpty);
   });
 }

--- a/test/wireless_connection_rollback_test.dart
+++ b/test/wireless_connection_rollback_test.dart
@@ -193,4 +193,18 @@ void main() {
     expect(modified, isTrue);
     expect(api.calls.where((call) => call.startsWith('/sbin/wifi ')), isEmpty);
   });
+
+  test('explicit restart refuses a disabled radio', () async {
+    final api = _FailingRestartApiService(radioDisabled: true);
+    final state = AppState.forTesting(
+      apiService: api,
+      authService: MockAuthService(),
+    );
+    addTearDown(state.dispose);
+
+    final restarted = await state.restartWirelessRadio('radio0');
+
+    expect(restarted, isFalse);
+    expect(api.calls.where((call) => call.startsWith('/sbin/wifi ')), isEmpty);
+  });
 }

--- a/test/wireless_connection_rollback_test.dart
+++ b/test/wireless_connection_rollback_test.dart
@@ -5,6 +5,9 @@ import 'package:luci_mobile/services/mock_auth_service.dart';
 import 'package:luci_mobile/state/app_state.dart';
 
 class _FailingRestartApiService extends MockApiService {
+  _FailingRestartApiService({this.failWirelessDelete = false});
+
+  final bool failWirelessDelete;
   final calls = <String>[];
 
   @override
@@ -90,6 +93,9 @@ class _FailingRestartApiService extends MockApiService {
     BuildContext? context,
   }) async {
     calls.add('delete $config.$section');
+    if (failWirelessDelete && config == 'wireless') {
+      throw Exception('forced wireless rollback failure');
+    }
     return [0, {}];
   }
 
@@ -142,5 +148,29 @@ void main() {
       hasLength(2),
     );
     expect(api.calls.last, '/sbin/wifi up radio0');
+  });
+
+  test('failed station rollback retains its committed dependencies', () async {
+    final api = _FailingRestartApiService(failWirelessDelete: true);
+    final state = AppState.forTesting(
+      apiService: api,
+      authService: MockAuthService(),
+    );
+    addTearDown(state.dispose);
+
+    final connected = await state.connectToWirelessNetwork(
+      radioDevice: 'radio0',
+      ssid: 'Test network',
+      encryption: 'psk2',
+      password: 'password123',
+    );
+
+    expect(connected, isFalse);
+    expect(api.calls, contains('delete wireless.wifinet0'));
+    expect(
+      api.calls,
+      isNot(contains('/sbin/uci del_list firewall.@zone[1].network=wwan')),
+    );
+    expect(api.calls, isNot(contains('delete network.wwan')));
   });
 }

--- a/test/wireless_connection_rollback_test.dart
+++ b/test/wireless_connection_rollback_test.dart
@@ -176,6 +176,7 @@ void main() {
       isNot(contains('/sbin/uci del_list firewall.@zone[1].network=wwan')),
     );
     expect(api.calls, isNot(contains('delete network.wwan')));
+    expect(state.dashboardError, contains('wireless section wifinet0'));
   });
 
   test('interface reload leaves disabled radios disabled', () async {

--- a/test/wireless_connection_rollback_test.dart
+++ b/test/wireless_connection_rollback_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:luci_mobile/services/mock_api_service.dart';
+import 'package:luci_mobile/services/mock_auth_service.dart';
+import 'package:luci_mobile/state/app_state.dart';
+
+class _FailingRestartApiService extends MockApiService {
+  final calls = <String>[];
+
+  @override
+  Future<dynamic> uciGetAll(
+    String ipAddress,
+    String sysauth,
+    bool useHttps, {
+    required String config,
+    BuildContext? context,
+  }) async {
+    final values = switch (config) {
+      'wireless' => {
+        'radio0': {'.type': 'wifi-device'},
+      },
+      'network' => {
+        'lan': {'.type': 'interface'},
+      },
+      'firewall' => {
+        'lan_zone': {'.type': 'zone', 'name': 'lan'},
+        'wan_zone': {
+          '.type': 'zone',
+          'name': 'wan',
+          'network': ['wan'],
+        },
+      },
+      _ => <String, dynamic>{},
+    };
+    return [
+      0,
+      {'values': values},
+    ];
+  }
+
+  @override
+  Future<dynamic> uciAdd(
+    String ipAddress,
+    String sysauth,
+    bool useHttps, {
+    required String config,
+    required String type,
+    required Map<String, dynamic> values,
+    String? name,
+    BuildContext? context,
+  }) async {
+    calls.add('add $config.$name');
+    return [0, name];
+  }
+
+  @override
+  Future<dynamic> uciSet(
+    String ipAddress,
+    String sysauth,
+    bool useHttps, {
+    required String config,
+    required String section,
+    required Map<String, String> values,
+    BuildContext? context,
+  }) async {
+    calls.add('set $config.$section $values');
+    return [0, {}];
+  }
+
+  @override
+  Future<dynamic> uciCommit(
+    String ipAddress,
+    String sysauth,
+    bool useHttps, {
+    required String config,
+    BuildContext? context,
+  }) async {
+    calls.add('commit $config');
+    return [0, {}];
+  }
+
+  @override
+  Future<dynamic> uciDelete(
+    String ipAddress,
+    String sysauth,
+    bool useHttps, {
+    required String config,
+    required String section,
+    String? option,
+    BuildContext? context,
+  }) async {
+    calls.add('delete $config.$section');
+    return [0, {}];
+  }
+
+  @override
+  Future<dynamic> systemExec(
+    String ipAddress,
+    String sysauth,
+    bool useHttps, {
+    required String command,
+    List<String> params = const [],
+    BuildContext? context,
+  }) async {
+    final call = '$command ${params.join(' ')}';
+    calls.add(call);
+    if (call == '/sbin/wifi down radio0') {
+      throw Exception('forced restart failure');
+    }
+    return [0, {}];
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('failed restart rolls back committed wireless dependencies', () async {
+    final api = _FailingRestartApiService();
+    final state = AppState.forTesting(
+      apiService: api,
+      authService: MockAuthService(),
+    );
+    addTearDown(state.dispose);
+
+    final connected = await state.connectToWirelessNetwork(
+      radioDevice: 'radio0',
+      ssid: 'Test network',
+      encryption: 'psk2',
+      password: 'password123',
+    );
+
+    expect(connected, isFalse);
+    expect(api.calls, contains('delete wireless.wifinet0'));
+    expect(
+      api.calls,
+      contains('/sbin/uci del_list firewall.@zone[1].network=wwan'),
+    );
+    expect(api.calls, contains('delete network.wwan'));
+    expect(api.calls, contains("set wireless.radio0 {disabled: 0}"));
+    expect(
+      api.calls.where((call) => call == '/sbin/wifi up radio0'),
+      hasLength(2),
+    );
+    expect(api.calls.last, '/sbin/wifi up radio0');
+  });
+}

--- a/test/wireless_connection_rollback_test.dart
+++ b/test/wireless_connection_rollback_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:luci_mobile/services/api_service.dart';
 import 'package:luci_mobile/services/mock_api_service.dart';
 import 'package:luci_mobile/services/mock_auth_service.dart';
 import 'package:luci_mobile/state/app_state.dart';
@@ -7,10 +8,12 @@ import 'package:luci_mobile/state/app_state.dart';
 class _FailingRestartApiService extends MockApiService {
   _FailingRestartApiService({
     this.failWirelessDelete = false,
+    this.failFirewallRead = false,
     this.radioDisabled = false,
   });
 
   final bool failWirelessDelete;
+  final bool failFirewallRead;
   final bool radioDisabled;
   final calls = <String>[];
 
@@ -22,6 +25,9 @@ class _FailingRestartApiService extends MockApiService {
     required String config,
     BuildContext? context,
   }) async {
+    if (config == 'firewall' && failFirewallRead) {
+      throw const RpcException(object: 'uci', method: 'get', status: 7);
+    }
     final values = switch (config) {
       'wireless' => {
         'radio0': {'.type': 'wifi-device', if (radioDisabled) 'disabled': '1'},
@@ -177,6 +183,27 @@ void main() {
     );
     expect(api.calls, isNot(contains('delete network.wwan')));
     expect(state.dashboardError, contains('wireless section wifinet0'));
+  });
+
+  test('firewall read failure aborts before staging wireless', () async {
+    final api = _FailingRestartApiService(failFirewallRead: true);
+    final state = AppState.forTesting(
+      apiService: api,
+      authService: MockAuthService(),
+    );
+    addTearDown(state.dispose);
+
+    final connected = await state.connectToWirelessNetwork(
+      radioDevice: 'radio0',
+      ssid: 'Test network',
+      encryption: 'psk2',
+      password: 'password123',
+    );
+
+    expect(connected, isFalse);
+    expect(api.calls, contains('delete network.wwan'));
+    expect(api.calls, isNot(contains('add wireless.wifinet0')));
+    expect(state.dashboardError, contains('timed out'));
   });
 
   test('interface reload leaves disabled radios disabled', () async {


### PR DESCRIPTION
This is a rebase of #54 on current upstream `main`.

## Changes

- **WiFi Scanner screen** — scan nearby networks via `iwinfo.scan`, connect as STA (station mode)
- **WiFi interface management** — edit, delete, and toggle UCI `wifi-iface` sections from the Interfaces screen
- **Restart radio** — UCI disable/enable cycle per radio (more reliable than `wifi reload`)
- **Cancel scan** — stop an ongoing network scan mid-flight

## Rebase notes

- All new API methods are declared through `lib/services/interfaces/api_service_interface.dart` (`IApiService`) so mock/reviewer mode keeps working — `scanWirelessNetworks`, `uciAdd`, `uciDelete`, `uciGetAll` are all in the interface and implemented in both `api_service.dart` and `mock_api_service.dart`
- Incorporated upstream `_uciString()` helper (from `fix(ui): handle UCI config values that may be List or String`) throughout `interfaces_screen.dart`
- Incorporated upstream AP-mode wireless station client enrichment (from `feat: add support for wireless stations in AP-mode routers`)
- Incorporated upstream optional `uciWirelessFuture` pattern (from `fix: make wireless UCI config optional for wired-only routers`)
- No new dependencies — `pubspec.lock` is upstream's

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a WiFi Scanner for visible and hidden networks, with signal, band, channel, and security details.
  * Added secure connection support with password validation, hidden-network handling, and connection feedback.
  * Added radio selection, scan cancellation, restart controls, and reliable scan results.
  * Enhanced wireless interface management with status toggles, editing, encryption details, deletion, and save support.
  * Added wireless configuration management and connection to discovered networks.
  * Added convenient WiFi Scanner access from Device Management.
  * Added clearer handling for unsupported enterprise networks and disabled radios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



























<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds Wi-Fi scanning and wireless station management, including UCI-backed interface updates, DHCP and firewall setup, radio restart behavior, and rollback handling.

Executed checks against the prior and current implementations disproved the previously reported failure paths: restart recovery restores a radio after a failed restart; interface toggle and edit flows handle reload errors; shared reloads preserve administratively disabled radios; explicit restart and station connection refuse disabled radios; UCI reads unwrap section values; missing `wwan` networks are created for every radio; DHCP creation, firewall reads, and network commits fail before a station is activated; and rollback preserves required dependencies when cleanup cannot complete.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains in the reviewed wireless management and station-setup flows.

No accepted blocking findings remain after the executed checks exercised the reported radio lifecycle, station creation, commit ordering, and rollback paths.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an authored radio-state validator comparing revision 2a6a711^ with HEAD; HEAD passes all 18 restart-recovery-related assertions.
- Ran an authored station-setup validator comparing revision 524d9f4~1 with HEAD; HEAD passes all 22 checks for UCI unwrapping, DHCP creation, commit ordering, firewall failures, rollback ordering, and cleanup reporting.
- Attempted flutter test test/wireless\_connection\_rollback\_test.dart but the environment has no Flutter executable, so the test could not run.
- The validation source shows before and after states: the before log records gaps like the missing WAN-cleanup guard, while the after log shows all 22 current contracts passing on HEAD.
- The runtime blocker log documents the exact Flutter command that failed and its exit code.

<a href="https://app.greptile.com/trex/runs/20190969/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (14): Last reviewed commit: ["fix: preserve disabled radios and networ..."](https://github.com/cogwheel0/luci-mobile/commit/524d9f4ae8530c6a451013b1fa73d7973ef0bedd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55803526)</sub>

<!-- /greptile_comment -->