### PR TITLE
fix: surface associated-station RPC errors and admin access

### DIFF
--- a/lib/screens/clients_screen.dart
+++ b/lib/screens/clients_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:luci_mobile/models/client.dart';
 import 'package:luci_mobile/main.dart';
+import 'package:luci_mobile/services/api_service.dart';
 import 'package:luci_mobile/widgets/luci_app_bar.dart';
 import 'package:luci_mobile/design/luci_design_system.dart';
 import 'package:luci_mobile/widgets/luci_loading_states.dart';
@@ -129,14 +130,18 @@ class _ClientsScreenState extends ConsumerState<ClientsScreen> {
                       );
                     }
 
-                    if (dashboardError != null && aggregatedClients.isEmpty) {
+                    final loadError = snapshot.hasError
+                        ? userFacingApiError(snapshot.error!)
+                        : dashboardError;
+                    if (loadError != null && aggregatedClients.isEmpty) {
                       return LuciErrorDisplay(
                         title: 'Failed to Load Clients',
-                        message:
-                            'Could not connect to the router. Please check your network connection and the router\'s IP address.',
+                        message: loadError,
                         actionLabel: 'Retry',
-                        onAction: () =>
-                            ref.read(appStateProvider).fetchDashboardData(),
+                        onAction: () async {
+                          await ref.read(appStateProvider).fetchDashboardData();
+                          if (mounted) setState(_computeClientsFuture);
+                        },
                         icon: Icons.wifi_off_rounded,
                       );
                     }

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1567,9 +1567,8 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
   Widget _buildBody(AppState appState) {
     if (appState.dashboardError != null) {
       return LuciErrorDisplay(
-        title: 'Connection Failed',
-        message:
-            'Unable to connect to the router. Please check your network connection and router settings.',
+        title: 'Unable to Load Dashboard',
+        message: appState.dashboardError!,
         actionLabel: 'Retry Connection',
         onAction: () => appState.fetchDashboardData(),
         icon: Icons.wifi_off_rounded,

--- a/lib/screens/interfaces_screen.dart
+++ b/lib/screens/interfaces_screen.dart
@@ -456,8 +456,7 @@ class _InterfacesScreenState extends ConsumerState<InterfacesScreen> {
                   if (dashboardError != null && dashboardData == null) {
                     return LuciErrorDisplay(
                       title: 'Failed to Load Interfaces',
-                      message:
-                          'Could not connect to the router. Please check your network connection and router settings.',
+                      message: dashboardError,
                       actionLabel: 'Retry',
                       onAction: () => appState.fetchDashboardData(),
                       icon: Icons.wifi_off_rounded,

--- a/lib/screens/more_screen.dart
+++ b/lib/screens/more_screen.dart
@@ -307,18 +307,28 @@ class _MoreScreenState extends ConsumerState<MoreScreen> {
                 final isRebooting = ref.watch(
                   appStateProvider.select((state) => state.isRebooting),
                 );
+                final canReboot = ref.watch(
+                  appStateProvider.select((state) => state.canReboot),
+                );
+                final rebootEnabled = canReboot == true && !isRebooting;
                 return _MoreScreenSection(
                   tiles: [
                     _buildMoreTile(
                       context,
-                      icon: Icons.restart_alt,
+                      icon: canReboot == false
+                          ? Icons.lock_outline
+                          : Icons.restart_alt,
                       iconColor: Theme.of(context).colorScheme.primary,
                       title: 'Reboot Router',
-                      subtitle: 'Perform a system restart',
-                      onTap: isRebooting
-                          ? null
-                          : () => _showRebootDialog(context),
-                      enabled: !isRebooting,
+                      subtitle: switch (canReboot) {
+                        false => 'View only — administrator access required',
+                        null => 'Checking administrator access…',
+                        true => 'Perform a system restart',
+                      },
+                      onTap: rebootEnabled
+                          ? () => _showRebootDialog(context)
+                          : null,
+                      enabled: rebootEnabled,
                       showSpinner: isRebooting,
                     ),
                   ],

--- a/lib/screens/more_screen.dart
+++ b/lib/screens/more_screen.dart
@@ -310,21 +310,29 @@ class _MoreScreenState extends ConsumerState<MoreScreen> {
                 final canReboot = ref.watch(
                   appStateProvider.select((state) => state.canReboot),
                 );
+                final accessError = ref.watch(
+                  appStateProvider.select((state) => state.rebootAccessError),
+                );
                 final rebootEnabled = canReboot == true && !isRebooting;
                 return _MoreScreenSection(
                   tiles: [
                     _buildMoreTile(
                       context,
-                      icon: canReboot == false
+                      icon: accessError != null
+                          ? Icons.error_outline
+                          : canReboot == false
                           ? Icons.lock_outline
                           : Icons.restart_alt,
                       iconColor: Theme.of(context).colorScheme.primary,
                       title: 'Reboot Router',
-                      subtitle: switch (canReboot) {
-                        false => 'View only — administrator access required',
-                        null => 'Checking administrator access…',
-                        true => 'Perform a system restart',
-                      },
+                      subtitle:
+                          accessError ??
+                          switch (canReboot) {
+                            false =>
+                              'View only — administrator access required',
+                            null => 'Checking administrator access…',
+                            true => 'Perform a system restart',
+                          },
                       onTap: rebootEnabled
                           ? () => _showRebootDialog(context)
                           : null,

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -13,6 +13,102 @@ class LoginResult {
   LoginResult({required this.token, required this.actualUseHttps});
 }
 
+class RpcException implements Exception {
+  final int? status;
+  final String object;
+  final String method;
+  final String? detail;
+
+  const RpcException({
+    required this.object,
+    required this.method,
+    this.status,
+    this.detail,
+  });
+
+  @override
+  String toString() {
+    final call = '$object.$method';
+    final unavailable =
+        status == 3 ||
+        status == 4 ||
+        status == 8 ||
+        detail?.toLowerCase().contains('not found') == true ||
+        detail?.toLowerCase().contains('not supported') == true;
+    if (unavailable && object == 'luci-rpc') {
+      return 'Router RPC support is missing: $call is unavailable. Install '
+          'rpcd-mod-luci, restart rpcd, then reconnect.';
+    }
+    if (unavailable && object == 'iwinfo') {
+      return 'Wireless client support is missing: $call is unavailable. '
+          'Install rpcd-mod-iwinfo, restart rpcd, then refresh.';
+    }
+    if (status == 6 ||
+        detail?.toLowerCase().contains('access denied') == true) {
+      return 'This account does not have permission for $call. Sign in with '
+          'an administrator account or grant the required RPC access.';
+    }
+
+    final reason = switch (status) {
+      1 => 'invalid command',
+      2 => 'invalid argument',
+      3 => 'method not found',
+      4 => 'object not found',
+      5 => 'no data',
+      7 => 'timed out',
+      8 => 'not supported',
+      9 => 'unknown error',
+      10 => 'connection failed',
+      _ => detail ?? 'unknown error',
+    };
+    return 'Router RPC call $call failed: ${detail ?? reason}.';
+  }
+}
+
+/// Validates the ubus `[status, data]` envelope while preserving it for
+/// existing callers.
+dynamic validateRpcResult(
+  dynamic result, {
+  required String object,
+  required String method,
+}) {
+  if (result is! List || result.isEmpty) return [0, result];
+
+  final status = result.first;
+  if (status is num && status.toInt() != 0) {
+    throw RpcException(
+      object: object,
+      method: method,
+      status: status.toInt(),
+      detail: result.length > 1 ? result[1]?.toString() : null,
+    );
+  }
+  return result;
+}
+
+bool? rpcAccessAllowed(dynamic result) {
+  if (result is List && result.length > 1 && result[0] == 0) {
+    final data = result[1];
+    if (data is Map && data['access'] is bool) return data['access'] as bool;
+  }
+  return null;
+}
+
+String userFacingApiError(Object error) {
+  if (error is RpcException) return error.toString();
+  if (error is DioException) {
+    final status = error.response?.statusCode;
+    if (status == 401 || status == 403) {
+      return 'The router rejected this session. Reconnect and check the '
+          'account\'s RPC permissions.';
+    }
+    if (status != null) return 'The router returned HTTP $status.';
+    return 'Could not connect to the router. Check its address and your '
+        'network connection, then try again.';
+  }
+  return error.toString().replaceFirst('Exception: ', '');
+}
+
 Uri _buildUrl(String ipAddress, bool useHttps, String path) {
   final scheme = useHttps ? 'https' : 'http';
   // Handle cases where ipAddress might already include a scheme
@@ -322,18 +418,26 @@ class RealApiService implements IApiService {
         final decoded = response.data is String
             ? jsonDecode(response.data as String)
             : response.data;
+        if (decoded is! Map) {
+          throw RpcException(
+            object: object,
+            method: method,
+            detail: 'invalid response',
+          );
+        }
         if (decoded['error'] != null) {
-          throw Exception('RPC error: ${decoded['error']['message']}');
+          final error = decoded['error'];
+          throw RpcException(
+            object: object,
+            method: method,
+            detail: error is Map ? error['message']?.toString() : '$error',
+          );
         }
-        // Return in LuCI RPC format: [status, data]
-        final result = decoded['result'];
-        if (result is List && result.isNotEmpty) {
-          // Result is already in [status, data] format
-          return result;
-        } else {
-          // Wrap single result in format: [0, data]
-          return [0, result];
-        }
+        return validateRpcResult(
+          decoded['result'],
+          object: object,
+          method: method,
+        );
       } else {
         throw Exception('Failed to call RPC: HTTP ${response.statusCode}');
       }
@@ -433,6 +537,8 @@ class RealApiService implements IApiService {
 
           for (final iface in interfaces) {
             if (iface is Map<String, dynamic>) {
+              final config = iface['config'];
+              if (config is Map && config['mode'] == 'sta') continue;
               final ifname = iface['ifname'] as String?;
               if (ifname != null) {
                 // Fetch associated stations for this interface
@@ -455,7 +561,7 @@ class RealApiService implements IApiService {
       return {};
     } catch (e, stack) {
       Logger.exception('Failed to fetch all associated stations', e, stack);
-      return {};
+      rethrow;
     }
   }
 
@@ -495,7 +601,7 @@ class RealApiService implements IApiService {
       return [];
     } catch (e, stack) {
       Logger.exception('Failed to fetch associated stations', e, stack);
-      return [];
+      rethrow;
     }
   }
 

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -522,10 +522,21 @@ class RealApiService implements IApiService {
       if (wirelessResult is List &&
           wirelessResult.length > 1 &&
           wirelessResult[0] == 0) {
-        final wirelessData = wirelessResult[1] as Map<String, dynamic>?;
-        if (wirelessData == null) return {};
+        final data = wirelessResult[1];
+        if (data is! Map<String, dynamic>) {
+          throw const RpcException(
+            object: 'luci-rpc',
+            method: 'getWirelessDevices',
+            detail: 'invalid response',
+          );
+        }
+        final wirelessData = data;
 
         final result = <String, Set<String>>{};
+        Object? firstError;
+        StackTrace? firstStack;
+        var attempted = 0;
+        var succeeded = 0;
 
         // For each wireless radio, get the associated stations
         for (final entry in wirelessData.entries) {
@@ -541,24 +552,37 @@ class RealApiService implements IApiService {
               if (config is Map && config['mode'] == 'sta') continue;
               final ifname = iface['ifname'] as String?;
               if (ifname != null) {
-                // Fetch associated stations for this interface
-                final stations = await fetchAssociatedStationsWithContext(
-                  ipAddress: ipAddress,
-                  sysauth: sysauth,
-                  useHttps: useHttps,
-                  interface: ifname,
-                  context: context?.mounted == true ? context : null,
-                );
-                if (stations.isNotEmpty) {
-                  result[ifname] = stations.toSet();
+                attempted++;
+                try {
+                  final stations = await fetchAssociatedStationsWithContext(
+                    ipAddress: ipAddress,
+                    sysauth: sysauth,
+                    useHttps: useHttps,
+                    interface: ifname,
+                    context: context?.mounted == true ? context : null,
+                  );
+                  succeeded++;
+                  if (stations.isNotEmpty) {
+                    result[ifname] = stations.toSet();
+                  }
+                } catch (e, stack) {
+                  firstError ??= e;
+                  firstStack ??= stack;
                 }
               }
             }
           }
         }
+        if (attempted > 0 && succeeded == 0 && firstError != null) {
+          Error.throwWithStackTrace(firstError, firstStack!);
+        }
         return result;
       }
-      return {};
+      throw const RpcException(
+        object: 'luci-rpc',
+        method: 'getWirelessDevices',
+        detail: 'invalid response',
+      );
     } catch (e, stack) {
       Logger.exception('Failed to fetch all associated stations', e, stack);
       rethrow;
@@ -598,7 +622,11 @@ class RealApiService implements IApiService {
               .toList();
         }
       }
-      return [];
+      throw const RpcException(
+        object: 'iwinfo',
+        method: 'assoclist',
+        detail: 'invalid response',
+      );
     } catch (e, stack) {
       Logger.exception('Failed to fetch associated stations', e, stack);
       rethrow;

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -72,14 +72,23 @@ dynamic validateRpcResult(
   required String object,
   required String method,
 }) {
-  if (result is! List || result.isEmpty) return [0, result];
-
-  final status = result.first;
-  if (status is num && status.toInt() != 0) {
+  if (result is! List ||
+      result.isEmpty ||
+      result.length > 2 ||
+      result.first is! int) {
     throw RpcException(
       object: object,
       method: method,
-      status: status.toInt(),
+      detail: 'invalid response',
+    );
+  }
+
+  final status = result.first as int;
+  if (status != 0) {
+    throw RpcException(
+      object: object,
+      method: method,
+      status: status,
       detail: result.length > 1 ? result[1]?.toString() : null,
     );
   }
@@ -87,7 +96,10 @@ dynamic validateRpcResult(
 }
 
 bool? rpcAccessAllowed(dynamic result) {
-  if (result is List && result.length > 1 && result[0] == 0) {
+  if (result is List &&
+      result.length == 2 &&
+      result[0] is int &&
+      result[0] == 0) {
     final data = result[1];
     if (data is Map && data['access'] is bool) return data['access'] as bool;
   }

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -508,6 +508,11 @@ class RealApiService implements IApiService {
     required bool useHttps,
     BuildContext? context,
   }) async {
+    const invalidResponse = RpcException(
+      object: 'luci-rpc',
+      method: 'getWirelessDevices',
+      detail: 'invalid response',
+    );
     try {
       // First, get wireless device information to find all wireless interfaces
       final wirelessResult = await callWithContext(
@@ -524,11 +529,7 @@ class RealApiService implements IApiService {
           wirelessResult[0] == 0) {
         final data = wirelessResult[1];
         if (data is! Map<String, dynamic>) {
-          throw const RpcException(
-            object: 'luci-rpc',
-            method: 'getWirelessDevices',
-            detail: 'invalid response',
-          );
+          throw invalidResponse;
         }
         final wirelessData = data;
 
@@ -540,36 +541,36 @@ class RealApiService implements IApiService {
 
         // For each wireless radio, get the associated stations
         for (final entry in wirelessData.entries) {
-          final radioData = entry.value as Map<String, dynamic>?;
-          if (radioData == null || radioData['interfaces'] == null) continue;
+          final radioData = entry.value;
+          if (radioData is! Map<String, dynamic>) throw invalidResponse;
+          final rawInterfaces = radioData['interfaces'];
+          if (rawInterfaces == null) continue;
+          if (rawInterfaces is! List) throw invalidResponse;
 
-          final interfaces = radioData['interfaces'] as List?;
-          if (interfaces == null) continue;
-
-          for (final iface in interfaces) {
-            if (iface is Map<String, dynamic>) {
-              final config = iface['config'];
-              if (config is Map && config['mode'] == 'sta') continue;
-              final ifname = iface['ifname'] as String?;
-              if (ifname != null) {
-                attempted++;
-                try {
-                  final stations = await fetchAssociatedStationsWithContext(
-                    ipAddress: ipAddress,
-                    sysauth: sysauth,
-                    useHttps: useHttps,
-                    interface: ifname,
-                    context: context?.mounted == true ? context : null,
-                  );
-                  succeeded++;
-                  if (stations.isNotEmpty) {
-                    result[ifname] = stations.toSet();
-                  }
-                } catch (e, stack) {
-                  firstError ??= e;
-                  firstStack ??= stack;
-                }
+          for (final iface in rawInterfaces) {
+            if (iface is! Map<String, dynamic>) throw invalidResponse;
+            final config = iface['config'];
+            if (config != null && config is! Map) throw invalidResponse;
+            if (config is Map && config['mode'] == 'sta') continue;
+            final ifname = iface['ifname'];
+            if (ifname == null) continue;
+            if (ifname is! String) throw invalidResponse;
+            attempted++;
+            try {
+              final stations = await fetchAssociatedStationsWithContext(
+                ipAddress: ipAddress,
+                sysauth: sysauth,
+                useHttps: useHttps,
+                interface: ifname,
+                context: context?.mounted == true ? context : null,
+              );
+              succeeded++;
+              if (stations.isNotEmpty) {
+                result[ifname] = stations.toSet();
               }
+            } catch (e, stack) {
+              firstError ??= e;
+              firstStack ??= stack;
             }
           }
         }
@@ -578,11 +579,7 @@ class RealApiService implements IApiService {
         }
         return result;
       }
-      throw const RpcException(
-        object: 'luci-rpc',
-        method: 'getWirelessDevices',
-        detail: 'invalid response',
-      );
+      throw invalidResponse;
     } catch (e, stack) {
       Logger.exception('Failed to fetch all associated stations', e, stack);
       rethrow;
@@ -598,6 +595,11 @@ class RealApiService implements IApiService {
     required String interface,
     BuildContext? context,
   }) async {
+    const invalidResponse = RpcException(
+      object: 'iwinfo',
+      method: 'assoclist',
+      detail: 'invalid response',
+    );
     try {
       final result = await callWithContext(
         ipAddress,
@@ -613,20 +615,16 @@ class RealApiService implements IApiService {
         final data = result[1];
         if (data is Map && data['results'] is List) {
           final resultsList = data['results'] as List;
-          return resultsList
-              .map(
-                (entry) => (entry as Map<String, dynamic>)['mac']?.toString(),
-              )
-              .where((mac) => mac != null)
-              .cast<String>()
-              .toList();
+          final macs = <String>[];
+          for (final entry in resultsList) {
+            if (entry is! Map<String, dynamic>) throw invalidResponse;
+            final mac = entry['mac'];
+            if (mac != null) macs.add(mac.toString());
+          }
+          return macs;
         }
       }
-      throw const RpcException(
-        object: 'iwinfo',
-        method: 'assoclist',
-        detail: 'invalid response',
-      );
+      throw invalidResponse;
     } catch (e, stack) {
       Logger.exception('Failed to fetch associated stations', e, stack);
       rethrow;

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -37,6 +37,7 @@ class AppState extends ChangeNotifier {
   String? _errorMessage;
   bool? _canReboot;
   String? _rebootAccessError;
+  int _rebootAccessRequestId = 0;
 
   Map<String, dynamic>? _dashboardData;
   bool _isDashboardLoading = false;
@@ -675,6 +676,7 @@ class AppState extends ChangeNotifier {
     _dashboardError = null;
     _canReboot = null;
     _rebootAccessError = null;
+    final rebootAccessRequestId = ++_rebootAccessRequestId;
     notifyListeners();
 
     unawaited(
@@ -683,6 +685,7 @@ class AppState extends ChangeNotifier {
         sysauth: sysauth,
         useHttps: useHttps,
         token: token,
+        requestId: rebootAccessRequestId,
       ),
     );
 
@@ -963,6 +966,7 @@ class AppState extends ChangeNotifier {
     required String sysauth,
     required bool useHttps,
     required int token,
+    required int requestId,
   }) async {
     bool? allowed;
     String? error;
@@ -983,7 +987,7 @@ class AppState extends ChangeNotifier {
       Logger.warning('Could not check reboot access: $e');
       error = 'Could not check administrator access. Refresh to retry.';
     }
-    if (token != _sessionToken) return;
+    if (token != _sessionToken || requestId != _rebootAccessRequestId) return;
     _canReboot = allowed;
     _rebootAccessError = error;
     notifyListeners();

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -35,6 +35,7 @@ class AppState extends ChangeNotifier {
 
   bool _isLoading = false;
   String? _errorMessage;
+  bool? _canReboot;
 
   Map<String, dynamic>? _dashboardData;
   bool _isDashboardLoading = false;
@@ -301,6 +302,7 @@ class AppState extends ChangeNotifier {
   String? get sysauth => _authService?.sysauth;
   bool get isLoading => _isLoading;
   String? get errorMessage => _errorMessage;
+  bool? get canReboot => _reviewerModeEnabled ? true : _canReboot;
 
   void setError(String error) {
     _errorMessage = error;
@@ -397,6 +399,7 @@ class AppState extends ChangeNotifier {
 
     _isLoading = true;
     _dashboardError = null;
+    _canReboot = null;
 
     // Clear throughput data when switching routers to prevent mixing data from different routers
     _cancelThroughputTimer();
@@ -463,6 +466,7 @@ class AppState extends ChangeNotifier {
     final token = _sessionToken;
     _isLoading = true;
     _errorMessage = null;
+    _canReboot = null;
 
     // Clear throughput data when logging in to prevent mixing data from different sessions
     _cancelThroughputTimer();
@@ -555,6 +559,7 @@ class AppState extends ChangeNotifier {
     if (token != _sessionToken) return;
     _dashboardData = null;
     _dashboardError = null;
+    _canReboot = null;
     _cancelThroughputTimer();
     // Optionally, do not clear routers or selectedRouter
     notifyListeners();
@@ -599,6 +604,7 @@ class AppState extends ChangeNotifier {
           '_lastUpdated':
               DateTime.now().millisecondsSinceEpoch, // Force UI updates
         };
+        _canReboot = true;
 
         // Update throughput data with mock network data for reviewer mode
         if (_throughputService != null) {
@@ -662,6 +668,15 @@ class AppState extends ChangeNotifier {
     _isDashboardLoading = true;
     _dashboardError = null;
     notifyListeners();
+
+    unawaited(
+      _refreshRebootAccess(
+        ip: ip,
+        sysauth: sysauth,
+        useHttps: useHttps,
+        token: token,
+      ),
+    );
 
     try {
       // Perform all API calls in parallel
@@ -920,12 +935,7 @@ class AppState extends ChangeNotifier {
     } catch (e) {
       // A newer session started; don't surface this fetch's error.
       if (token != _sessionToken) return;
-      final errorMessage = e.toString();
-      if (errorMessage.contains('Access denied')) {
-        _dashboardError = 'Access Denied: Check RPC permissions for this user.';
-      } else {
-        _dashboardError = 'Failed to fetch dashboard data: $e';
-      }
+      _dashboardError = userFacingApiError(e);
       // Log error with stack trace for debugging
       // print('Dashboard fetch error: $e\n$stack');
       // Clear dashboard data when there's an error so we don't show stale data
@@ -938,6 +948,31 @@ class AppState extends ChangeNotifier {
         notifyListeners();
       }
     }
+  }
+
+  Future<void> _refreshRebootAccess({
+    required String ip,
+    required String sysauth,
+    required bool useHttps,
+    required int token,
+  }) async {
+    bool? allowed;
+    try {
+      final result = await _apiService!.call(
+        ip,
+        sysauth,
+        useHttps,
+        object: 'session',
+        method: 'access',
+        params: {'scope': 'ubus', 'object': 'system', 'function': 'reboot'},
+      );
+      allowed = rpcAccessAllowed(result);
+    } catch (e) {
+      Logger.warning('Could not check reboot access: $e');
+    }
+    if (token != _sessionToken) return;
+    _canReboot = allowed;
+    notifyListeners();
   }
 
   Map<String, dynamic> _processDhcpLeases(Map<String, dynamic> rawDhcpData) {
@@ -1174,6 +1209,7 @@ class AppState extends ChangeNotifier {
   }
 
   Future<bool> reboot({BuildContext? context}) async {
+    if (!_reviewerModeEnabled && _canReboot != true) return false;
     if (_authService?.sysauth == null || _authService?.ipAddress == null) {
       return false;
     }
@@ -1655,7 +1691,7 @@ class AppState extends ChangeNotifier {
       return list;
     } catch (e, stack) {
       Logger.exception('Failed to aggregate clients', e, stack);
-      return [];
+      Error.throwWithStackTrace(e, stack);
     }
   }
 
@@ -1804,7 +1840,7 @@ class AppState extends ChangeNotifier {
       return clients;
     } catch (e, stack) {
       Logger.exception('Failed to fetch clients for selected router', e, stack);
-      return [];
+      Error.throwWithStackTrace(e, stack);
     }
   }
 
@@ -1823,6 +1859,9 @@ class AppState extends ChangeNotifier {
       final routers = _routerService?.routers ?? const <model.Router>[];
       if (routers.isEmpty) return {};
 
+      Object? firstError;
+      StackTrace? firstStack;
+      var successfulRouters = 0;
       final tasks = routers.map((r) async {
         try {
           if (_apiService is RealApiService) {
@@ -1833,30 +1872,37 @@ class AppState extends ChangeNotifier {
               r.password,
               r.useHttps,
             );
-            if (res.token == null) return <String>{};
+            if (res.token == null) {
+              throw Exception('Login failed for ${r.ipAddress}');
+            }
             final map = await _apiService!
                 .fetchAllAssociatedWirelessMacsWithContext(
                   ipAddress: r.ipAddress,
                   sysauth: res.token!,
                   useHttps: res.actualUseHttps,
                 );
+            successfulRouters++;
             final set = <String>{};
             map.forEach((_, stations) {
               set.addAll(stations.map((m) => m.toLowerCase()));
             });
             return set;
           }
-        } catch (e) {
-          // Skip router on failure
+        } catch (e, stack) {
+          firstError ??= e;
+          firstStack ??= stack;
         }
         return <String>{};
       }).toList();
 
       final results = await Future.wait(tasks);
+      if (successfulRouters == 0 && firstError != null) {
+        Error.throwWithStackTrace(firstError!, firstStack!);
+      }
       return results.fold<Set<String>>(<String>{}, (acc, s) => acc..addAll(s));
     } catch (e, stack) {
       Logger.exception('Failed to aggregate wireless MACs', e, stack);
-      return {};
+      Error.throwWithStackTrace(e, stack);
     }
   }
 
@@ -1882,6 +1928,9 @@ class AppState extends ChangeNotifier {
       final routers = _routerService?.routers ?? const <model.Router>[];
       if (routers.isEmpty) return [];
 
+      Object? firstError;
+      StackTrace? firstStack;
+      var successfulRouters = 0;
       final tasks = routers.map((r) async {
         try {
           if (_apiService is RealApiService) {
@@ -1892,7 +1941,9 @@ class AppState extends ChangeNotifier {
               r.password,
               r.useHttps,
             );
-            if (res.token == null) return <Map<String, dynamic>>[];
+            if (res.token == null) {
+              throw Exception('Login failed for ${r.ipAddress}');
+            }
             final callRes = await _apiService!.call(
               r.ipAddress,
               res.token!,
@@ -1905,16 +1956,21 @@ class AppState extends ChangeNotifier {
               final data = callRes[1] as Map<String, dynamic>;
               final leases = (data['dhcp_leases'] as List<dynamic>? ?? [])
                   .cast<Map<String, dynamic>>();
+              successfulRouters++;
               return leases;
             }
           }
-        } catch (e) {
-          // Skip router on failure
+        } catch (e, stack) {
+          firstError ??= e;
+          firstStack ??= stack;
         }
         return <Map<String, dynamic>>[];
       }).toList();
 
       final results = await Future.wait(tasks);
+      if (successfulRouters == 0 && firstError != null) {
+        Error.throwWithStackTrace(firstError!, firstStack!);
+      }
       // Deduplicate by MAC + IP
       final seen = <String, Map<String, dynamic>>{};
       for (final list in results) {
@@ -1930,7 +1986,7 @@ class AppState extends ChangeNotifier {
       return seen.values.toList();
     } catch (e, stack) {
       Logger.exception('Failed to aggregate DHCP leases', e, stack);
-      return [];
+      Error.throwWithStackTrace(e, stack);
     }
   }
 }

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -36,6 +36,7 @@ class AppState extends ChangeNotifier {
   bool _isLoading = false;
   String? _errorMessage;
   bool? _canReboot;
+  String? _rebootAccessError;
 
   Map<String, dynamic>? _dashboardData;
   bool _isDashboardLoading = false;
@@ -303,6 +304,7 @@ class AppState extends ChangeNotifier {
   bool get isLoading => _isLoading;
   String? get errorMessage => _errorMessage;
   bool? get canReboot => _reviewerModeEnabled ? true : _canReboot;
+  String? get rebootAccessError => _rebootAccessError;
 
   void setError(String error) {
     _errorMessage = error;
@@ -400,6 +402,7 @@ class AppState extends ChangeNotifier {
     _isLoading = true;
     _dashboardError = null;
     _canReboot = null;
+    _rebootAccessError = null;
 
     // Clear throughput data when switching routers to prevent mixing data from different routers
     _cancelThroughputTimer();
@@ -467,6 +470,7 @@ class AppState extends ChangeNotifier {
     _isLoading = true;
     _errorMessage = null;
     _canReboot = null;
+    _rebootAccessError = null;
 
     // Clear throughput data when logging in to prevent mixing data from different sessions
     _cancelThroughputTimer();
@@ -560,6 +564,7 @@ class AppState extends ChangeNotifier {
     _dashboardData = null;
     _dashboardError = null;
     _canReboot = null;
+    _rebootAccessError = null;
     _cancelThroughputTimer();
     // Optionally, do not clear routers or selectedRouter
     notifyListeners();
@@ -605,6 +610,7 @@ class AppState extends ChangeNotifier {
               DateTime.now().millisecondsSinceEpoch, // Force UI updates
         };
         _canReboot = true;
+        _rebootAccessError = null;
 
         // Update throughput data with mock network data for reviewer mode
         if (_throughputService != null) {
@@ -667,6 +673,8 @@ class AppState extends ChangeNotifier {
 
     _isDashboardLoading = true;
     _dashboardError = null;
+    _canReboot = null;
+    _rebootAccessError = null;
     notifyListeners();
 
     unawaited(
@@ -957,6 +965,7 @@ class AppState extends ChangeNotifier {
     required int token,
   }) async {
     bool? allowed;
+    String? error;
     try {
       final result = await _apiService!.call(
         ip,
@@ -967,11 +976,16 @@ class AppState extends ChangeNotifier {
         params: {'scope': 'ubus', 'object': 'system', 'function': 'reboot'},
       );
       allowed = rpcAccessAllowed(result);
+      if (allowed == null) {
+        error = 'Could not check administrator access. Refresh to retry.';
+      }
     } catch (e) {
       Logger.warning('Could not check reboot access: $e');
+      error = 'Could not check administrator access. Refresh to retry.';
     }
     if (token != _sessionToken) return;
     _canReboot = allowed;
+    _rebootAccessError = error;
     notifyListeners();
   }
 
@@ -1633,14 +1647,44 @@ class AppState extends ChangeNotifier {
   /// as wireless if their MAC appears in any router's associated stations list.
   Future<List<Client>> fetchAggregatedClients() async {
     try {
-      // Build a union of wireless MACs across all routers
-      final wirelessMacs = await fetchAllAssociatedWirelessMacsAggregated();
+      var wirelessMacs = <String>{};
+      Object? wirelessError;
+      StackTrace? wirelessStack;
+      try {
+        wirelessMacs = await fetchAllAssociatedWirelessMacsAggregated();
+      } catch (e, stack) {
+        wirelessError = e;
+        wirelessStack = stack;
+      }
+
+      var leases = <Map<String, dynamic>>[];
+      Object? leaseError;
+      StackTrace? leaseStack;
+      try {
+        leases = await fetchAggregatedDhcpLeases();
+      } catch (e, stack) {
+        leaseError = e;
+        leaseStack = stack;
+      }
+
+      if (wirelessError != null) {
+        if (leases.isEmpty) {
+          Error.throwWithStackTrace(wirelessError, wirelessStack!);
+        }
+        Logger.warning(
+          'Using DHCP clients without wireless data: $wirelessError',
+        );
+      }
+      if (leaseError != null) {
+        if (wirelessMacs.isEmpty) {
+          Error.throwWithStackTrace(leaseError, leaseStack!);
+        }
+        Logger.warning('Using wireless clients without DHCP data: $leaseError');
+      }
+
       final normalizedWireless = wirelessMacs
           .map((m) => m.toUpperCase().replaceAll('-', ':'))
           .toSet();
-
-      // Aggregate leases across routers
-      final leases = await fetchAggregatedDhcpLeases();
 
       // Convert to Client models with connection type
       final clients = <String, Client>{}; // key by normalized MAC
@@ -1764,34 +1808,67 @@ class AppState extends ChangeNotifier {
       }
       final router = _routerService!.selectedRouter!;
 
-      // Get wireless MACs for this router
-      final stationsMap = await _apiService!
-          .fetchAllAssociatedWirelessMacsWithContext(
-            ipAddress: router.ipAddress,
-            sysauth: _authService!.sysauth!,
-            useHttps: router.useHttps,
-          );
       final wireless = <String>{};
-      stationsMap.forEach(
-        (_, s) => wireless.addAll(s.map((m) => m.toLowerCase())),
-      );
+      Object? wirelessError;
+      StackTrace? wirelessStack;
+      try {
+        final stationsMap = await _apiService!
+            .fetchAllAssociatedWirelessMacsWithContext(
+              ipAddress: router.ipAddress,
+              sysauth: _authService!.sysauth!,
+              useHttps: router.useHttps,
+            );
+        stationsMap.forEach(
+          (_, stations) =>
+              wireless.addAll(stations.map((mac) => mac.toLowerCase())),
+        );
+      } catch (e, stack) {
+        wirelessError = e;
+        wirelessStack = stack;
+      }
 
-      // Get DHCP leases for this router
-      final callRes = await _apiService!.call(
-        router.ipAddress,
-        _authService!.sysauth!,
-        router.useHttps,
-        object: 'luci-rpc',
-        method: 'getDHCPLeases',
-        params: {},
-      );
       final leases = <Map<String, dynamic>>[];
-      if (callRes is List && callRes.length > 1 && callRes[0] == 0) {
+      Object? leaseError;
+      StackTrace? leaseStack;
+      try {
+        final callRes = await _apiService!.call(
+          router.ipAddress,
+          _authService!.sysauth!,
+          router.useHttps,
+          object: 'luci-rpc',
+          method: 'getDHCPLeases',
+          params: {},
+        );
+        if (callRes is! List || callRes.length < 2 || callRes[0] != 0) {
+          throw const RpcException(
+            object: 'luci-rpc',
+            method: 'getDHCPLeases',
+            detail: 'invalid response',
+          );
+        }
         final data = callRes[1] as Map<String, dynamic>;
         leases.addAll(
           (data['dhcp_leases'] as List<dynamic>? ?? [])
               .cast<Map<String, dynamic>>(),
         );
+      } catch (e, stack) {
+        leaseError = e;
+        leaseStack = stack;
+      }
+
+      if (wirelessError != null) {
+        if (leases.isEmpty) {
+          Error.throwWithStackTrace(wirelessError, wirelessStack!);
+        }
+        Logger.warning(
+          'Using DHCP clients without wireless data: $wirelessError',
+        );
+      }
+      if (leaseError != null) {
+        if (wireless.isEmpty) {
+          Error.throwWithStackTrace(leaseError, leaseStack!);
+        }
+        Logger.warning('Using wireless clients without DHCP data: $leaseError');
       }
 
       // Normalize wireless MACs for consistent lookup
@@ -1959,6 +2036,11 @@ class AppState extends ChangeNotifier {
               successfulRouters++;
               return leases;
             }
+            throw const RpcException(
+              object: 'luci-rpc',
+              method: 'getDHCPLeases',
+              detail: 'invalid response',
+            );
           }
         } catch (e, stack) {
           firstError ??= e;

--- a/test/rpc_response_test.dart
+++ b/test/rpc_response_test.dart
@@ -1,7 +1,10 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:luci_mobile/services/api_service.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   test('missing luci-rpc package produces an actionable error', () {
     expect(
       () => validateRpcResult([4], object: 'luci-rpc', method: 'getDHCPLeases'),
@@ -58,4 +61,95 @@ void main() {
     );
     expect(rpcAccessAllowed([0, {}]), isNull);
   });
+
+  test('associated stations survive one failing wireless interface', () async {
+    final api = _StationApi(
+      stations: {
+        'wlan0': ['AA:BB:CC:DD:EE:FF'],
+        'wlan1': Exception('interface down'),
+      },
+    );
+
+    final result = await api.fetchAllAssociatedWirelessMacsWithContext(
+      ipAddress: 'router',
+      sysauth: 'token',
+      useHttps: false,
+    );
+
+    expect(result['wlan0'], {'AA:BB:CC:DD:EE:FF'});
+  });
+
+  test('associated stations fail when every interface fails', () async {
+    final api = _StationApi(stations: {'wlan0': Exception('interface down')});
+
+    expect(
+      api.fetchAllAssociatedWirelessMacsWithContext(
+        ipAddress: 'router',
+        sysauth: 'token',
+        useHttps: false,
+      ),
+      throwsException,
+    );
+  });
+
+  test('associated stations reject an invalid device response', () async {
+    final api = _StationApi(stations: {}, wirelessResponse: [0]);
+
+    expect(
+      api.fetchAllAssociatedWirelessMacsWithContext(
+        ipAddress: 'router',
+        sysauth: 'token',
+        useHttps: false,
+      ),
+      throwsA(isA<RpcException>()),
+    );
+  });
+}
+
+class _StationApi extends RealApiService {
+  final Map<String, Object> stations;
+  final dynamic wirelessResponse;
+
+  _StationApi({required this.stations, this.wirelessResponse});
+
+  @override
+  Future<dynamic> callWithContext(
+    String ipAddress,
+    String sysauth,
+    bool useHttps, {
+    required String object,
+    required String method,
+    Map<String, dynamic>? params,
+    BuildContext? context,
+  }) async {
+    if (wirelessResponse != null) return wirelessResponse;
+    return [
+      0,
+      {
+        'radio0': {
+          'interfaces': stations.keys
+              .map(
+                (ifname) => {
+                  'ifname': ifname,
+                  'config': {'mode': 'ap'},
+                },
+              )
+              .toList(),
+        },
+      },
+    ];
+  }
+
+  @override
+  Future<List<String>> fetchAssociatedStationsWithContext({
+    required String ipAddress,
+    required String sysauth,
+    required bool useHttps,
+    required String interface,
+    BuildContext? context,
+  }) async {
+    final result = stations[interface]!;
+    if (result is Exception) throw result;
+    return result as List<String>;
+  }
 }

--- a/test/rpc_response_test.dart
+++ b/test/rpc_response_test.dart
@@ -104,13 +104,59 @@ void main() {
       throwsA(isA<RpcException>()),
     );
   });
+
+  test('associated stations reject an invalid radio payload', () async {
+    final api = _StationApi(
+      stations: {},
+      wirelessResponse: [
+        0,
+        {'radio0': 1},
+      ],
+    );
+
+    expect(
+      api.fetchAllAssociatedWirelessMacsWithContext(
+        ipAddress: 'router',
+        sysauth: 'token',
+        useHttps: false,
+      ),
+      throwsA(isA<RpcException>()),
+    );
+  });
+
+  test('associated stations reject an invalid station entry', () async {
+    final api = _StationApi(
+      stations: {},
+      stationResponse: [
+        0,
+        {
+          'results': ['bad'],
+        },
+      ],
+    );
+
+    expect(
+      api.fetchAssociatedStationsWithContext(
+        ipAddress: 'router',
+        sysauth: 'token',
+        useHttps: false,
+        interface: 'wlan0',
+      ),
+      throwsA(isA<RpcException>()),
+    );
+  });
 }
 
 class _StationApi extends RealApiService {
   final Map<String, Object> stations;
   final dynamic wirelessResponse;
+  final dynamic stationResponse;
 
-  _StationApi({required this.stations, this.wirelessResponse});
+  _StationApi({
+    required this.stations,
+    this.wirelessResponse,
+    this.stationResponse,
+  });
 
   @override
   Future<dynamic> callWithContext(
@@ -122,6 +168,9 @@ class _StationApi extends RealApiService {
     Map<String, dynamic>? params,
     BuildContext? context,
   }) async {
+    if (method == 'assoclist' && stationResponse != null) {
+      return stationResponse;
+    }
     if (wirelessResponse != null) return wirelessResponse;
     return [
       0,
@@ -148,6 +197,15 @@ class _StationApi extends RealApiService {
     required String interface,
     BuildContext? context,
   }) async {
+    if (stationResponse != null) {
+      return super.fetchAssociatedStationsWithContext(
+        ipAddress: ipAddress,
+        sysauth: sysauth,
+        useHttps: useHttps,
+        interface: interface,
+        context: context,
+      );
+    }
     final result = stations[interface]!;
     if (result is Exception) throw result;
     return result as List<String>;

--- a/test/rpc_response_test.dart
+++ b/test/rpc_response_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:luci_mobile/services/api_service.dart';
+
+void main() {
+  test('missing luci-rpc package produces an actionable error', () {
+    expect(
+      () => validateRpcResult([4], object: 'luci-rpc', method: 'getDHCPLeases'),
+      throwsA(
+        isA<RpcException>().having(
+          (error) => error.toString(),
+          'message',
+          contains('Install rpcd-mod-luci'),
+        ),
+      ),
+    );
+  });
+
+  test('missing iwinfo package produces an actionable error', () {
+    expect(
+      () => validateRpcResult([3], object: 'iwinfo', method: 'assoclist'),
+      throwsA(
+        isA<RpcException>().having(
+          (error) => error.toString(),
+          'message',
+          contains('Install rpcd-mod-iwinfo'),
+        ),
+      ),
+    );
+  });
+
+  test('permission denial identifies the blocked action', () {
+    expect(
+      () => validateRpcResult([6], object: 'system', method: 'reboot'),
+      throwsA(
+        isA<RpcException>().having(
+          (error) => error.toString(),
+          'message',
+          contains('permission for system.reboot'),
+        ),
+      ),
+    );
+  });
+
+  test('access response distinguishes admin and view-only sessions', () {
+    expect(
+      rpcAccessAllowed([
+        0,
+        {'access': true},
+      ]),
+      isTrue,
+    );
+    expect(
+      rpcAccessAllowed([
+        0,
+        {'access': false},
+      ]),
+      isFalse,
+    );
+    expect(rpcAccessAllowed([0, {}]), isNull);
+  });
+}

--- a/test/rpc_response_test.dart
+++ b/test/rpc_response_test.dart
@@ -44,6 +44,29 @@ void main() {
     );
   });
 
+  test('RPC validation rejects malformed envelopes', () {
+    expect(
+      () => validateRpcResult(
+        {'access': true},
+        object: 'session',
+        method: 'access',
+      ),
+      throwsA(isA<RpcException>()),
+    );
+    expect(
+      () => validateRpcResult(
+        [
+          0.0,
+          {'access': true},
+        ],
+        object: 'session',
+        method: 'access',
+      ),
+      throwsA(isA<RpcException>()),
+    );
+    expect(validateRpcResult([0], object: 'system', method: 'reboot'), [0]);
+  });
+
   test('access response distinguishes admin and view-only sessions', () {
     expect(
       rpcAccessAllowed([


### PR DESCRIPTION
## Summary

- stop associated-station RPC failures from masquerading as an empty client list
- preserve working radios and DHCP/station data when another source fails
- show actionable errors for missing `rpcd-mod-luci`, missing `rpcd-mod-iwinfo`, malformed responses, and denied RPC calls
- check `session.access` before reboot and distinguish checking, view-only, and permission-check failure states

## Validation

- `flutter analyze`
- `flutter test` (42 tests)

This intentionally includes the current reboot permission gate; #68 can apply the same per-action check to its future Wi-Fi write actions.

Fixes #21
Fixes #45
Fixes #52
Related to #68.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update hardens router RPC handling and reboot authorization. Malformed access responses are rejected before they can enable a privileged action, and focused runtime checks confirm that denied, malformed, false, and stale permission results keep reboot unavailable while an explicit current grant allows it.

The earlier malformed-RPC reboot authorization concern is resolved: the same focused test reproduced the prior behavior on the parent revision and passed on the current revision after confirming malformed data throws rather than authorizing access.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains; the reboot permission flow rejects invalid and non-current authorization responses.

No accepted blocking findings remain. Focused Flutter checks exercised malformed, denied, false, stale, and explicitly granted reboot-access outcomes.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The team ran an authored Flutter test comparing the parent revision and the current revision to verify that a malformed RPC envelope does not grant reboot access and that a valid explicit access grant continues to work.
- A focused Flutter authorization test in a Flutter container validated that denied, malformed, explicit-false, and stale access results do not trigger reboot, while a current explicit-true access triggers reboot exactly once; all tests exited with code 0.
- The test expectation was updated to reject malformed access even when the closure previously returned true; the updated tests all passed.
- The test source and runtime results for the reboot access authorization tests were documented, including a link to the test source and the runtime result showing all three authorization-path tests passed with exit code 0.

<a href="https://app.greptile.com/trex/runs/20186147/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: reject malformed RPC envelopes"](https://github.com/cogwheel0/luci-mobile/commit/9bb05eb30d5dbd2a2852167122f6d8e3a3a49a68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55882218)</sub>

<!-- /greptile_comment -->