### PR TITLE
fix: harden fallback address handling

### DIFF
--- a/lib/screens/manage_routers_screen.dart
+++ b/lib/screens/manage_routers_screen.dart
@@ -894,7 +894,30 @@ class _UnifiedRouterCard extends StatelessWidget {
                 IconButton(
                   icon: const Icon(Icons.link_off),
                   tooltip: 'Remove fallback address',
-                  onPressed: onRemoveFallback,
+                  onPressed: () async {
+                    final confirm = await showDialog<bool>(
+                      context: context,
+                      builder: (context) => AlertDialog(
+                        title: const Text('Remove Fallback Address'),
+                        content: const Text(
+                          'Are you sure you want to remove the fallback address?',
+                        ),
+                        actions: [
+                          TextButton(
+                            onPressed: () => Navigator.pop(context, false),
+                            child: const Text('Cancel'),
+                          ),
+                          TextButton(
+                            onPressed: () => Navigator.pop(context, true),
+                            child: const Text('Remove'),
+                          ),
+                        ],
+                      ),
+                    );
+                    if (confirm == true && context.mounted) {
+                      onRemoveFallback!();
+                    }
+                  },
                 ),
               if (onDelete != null)
                 IconButton(

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1270,7 +1270,8 @@ class AppState extends ChangeNotifier {
 
     // Use the address that actually succeeded during login
     final ip =
-        _authService!.ipAddress ?? _routerService!.selectedRouter!.ipAddress;
+        _authService!.ipAddress ??
+        _routerService!.selectedRouter!.activeAddress;
     final useHttps = _authService!.useHttps;
 
     try {
@@ -2802,7 +2803,8 @@ class AppState extends ChangeNotifier {
 
       // Use the address that actually succeeded during login
       final ip =
-          _authService!.ipAddress ?? _routerService!.selectedRouter!.ipAddress;
+          _authService!.ipAddress ??
+          _routerService!.selectedRouter!.activeAddress;
       final useHttps = _authService!.useHttps;
 
       final stationsMap = await _apiService!

--- a/test/manage_routers_screen_test.dart
+++ b/test/manage_routers_screen_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:luci_mobile/main.dart';
+import 'package:luci_mobile/models/router.dart' as model;
+import 'package:luci_mobile/screens/manage_routers_screen.dart';
+import 'package:luci_mobile/services/mock_api_service.dart';
+import 'package:luci_mobile/services/mock_auth_service.dart';
+import 'package:luci_mobile/state/app_state.dart';
+
+void main() {
+  testWidgets('fallback removal requires confirmation', (tester) async {
+    final state = _TestAppState(
+      model.Router(
+        id: 'router',
+        ipAddress: '192.168.1.1',
+        username: 'root',
+        password: 'password',
+        useHttps: false,
+        alternateAddress: 'router.example.com',
+        alternateUseHttps: true,
+      ),
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [appStateProvider.overrideWith((ref) => state)],
+        child: const MaterialApp(home: ManageRoutersScreen()),
+      ),
+    );
+
+    await tester.tap(find.byTooltip('Remove fallback address'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+    expect(state.updatedRouter, isNull);
+
+    await tester.tap(find.byTooltip('Remove fallback address'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Remove'));
+    await tester.pumpAndSettle();
+    expect(state.updatedRouter?.hasFallback, isFalse);
+  });
+}
+
+class _TestAppState extends AppState {
+  _TestAppState(this.router)
+    : super.forTesting(
+        apiService: MockApiService(),
+        authService: MockAuthService(),
+      );
+
+  final model.Router router;
+  model.Router? updatedRouter;
+
+  @override
+  List<model.Router> get routers => [router];
+
+  @override
+  Future<void> updateRouter(model.Router router) async =>
+      updatedRouter = router;
+}


### PR DESCRIPTION
## Summary

- confirm before removing a saved fallback address
- keep throughput and associated-station requests on the router active address when the authenticated address is unavailable
- cover fallback removal cancellation and confirmation

Follow-up to #57.

## Tests

- `flutter analyze`
- `flutter test` (81 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a confirmation prompt before removing a router’s fallback address, helping prevent accidental changes.

- **Bug Fixes**
  - Updated router network operations to use the currently active address when the authenticated address is unavailable.

- **Tests**
  - Added coverage verifying that cancellation preserves the fallback address and confirmation removes it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change requires confirmation before removing a router fallback address and uses the router’s currently active address when authenticated address state is unavailable for dashboard and throughput requests.

No defects are reported.

## T-Rex validation blocked

The Flutter SDK tool is unavailable: `flutter` is not on PATH. Focused fallback-routing and fallback-removal widget test commands both exited with status 127 before executing application code. Provision Flutter and run `flutter test test/fallback_address_test.dart test/manage_routers_screen_test.dart` to exercise these flows.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No product defect was identified in the changed fallback-address handling or confirmation flow.

There are no final findings. The focused Flutter checks could not run because the required Flutter tool is unavailable, so runtime behavior should be exercised after provisioning the SDK.

**Files Needing Attention:** No file requires a code change. Re-run the focused tests covering `lib/state/app_state.dart` and `lib/screens/manage_routers_screen.dart` once Flutter is available.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Tests could not be run because the Flutter CLI was not found on PATH; both flutter test invocations exited with status 127.
- Committed fallback-removal test source and its checksum were captured to enable a runnable check.
- Confirmed the runtime requirement that Flutter must be available on PATH in order to run Flutter tests.

<a href="https://app.greptile.com/trex/runs/20234117/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: harden fallback address handling"](https://github.com/cogwheel0/luci-mobile/commit/63572665e4f9e9aa2733f463287a15b418771832) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55980363)</sub>

<!-- /greptile_comment -->